### PR TITLE
feat: allow changing fader levels from -Infinity dB

### DIFF
--- a/packages/mixer-connection/src/lib/facade/channel.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/channel.spec.ts
@@ -49,6 +49,14 @@ describe('Channel', () => {
       channel.changeFaderLevelDB(-6);
       expect(await firstValueFrom(channel.faderLevelDB$)).toBe(-15);
     });
+
+    it('should change level from -Infinity dB upwards', async () => {
+      channel.setFaderLevel(0); // -Infinity dB
+      channel.changeFaderLevelDB(3);
+
+      expect(await firstValueFrom(channel.faderLevelDB$)).toBe(-97);
+      expect(await firstValueFrom(channel.faderLevel$)).not.toBe(0);
+    });
   });
 
   describe('MUTE', () => {

--- a/packages/mixer-connection/src/lib/facade/channel.ts
+++ b/packages/mixer-connection/src/lib/facade/channel.ts
@@ -133,7 +133,9 @@ export class Channel implements FadeableChannel {
    * @param offsetDB value (dB) to add to the current value
    */
   changeFaderLevelDB(offsetDB: number) {
-    this.faderLevelDB$.pipe(take(1)).subscribe(v => this.setFaderLevelDB(v + offsetDB));
+    this.faderLevelDB$
+      .pipe(take(1))
+      .subscribe(v => this.setFaderLevelDB(Math.max(v, -100) + offsetDB));
   }
 
   /**

--- a/packages/mixer-connection/src/lib/facade/fx-channel.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/fx-channel.spec.ts
@@ -48,6 +48,14 @@ describe('AUX Channel', () => {
       channel.changeFaderLevelDB(-6);
       expect(await firstValueFrom(channel.faderLevelDB$)).toBe(-15);
     });
+
+    it('should change level from -Infinity dB upwards', async () => {
+      channel.setFaderLevel(0); // -Infinity dB
+      channel.changeFaderLevelDB(3);
+
+      expect(await firstValueFrom(channel.faderLevelDB$)).toBe(-97);
+      expect(await firstValueFrom(channel.faderLevel$)).not.toBe(0);
+    });
   });
 
   describe('PRE/POST', () => {

--- a/packages/mixer-connection/src/lib/facade/master-bus.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/master-bus.spec.ts
@@ -121,4 +121,14 @@ describe('Master Bus', () => {
       expect(await firstValueFrom(master.delayR$)).toBe(0);
     });
   });
+
+  describe('fader level', () => {
+    it('should change level from -Infinity dB upwards', async () => {
+      master.setFaderLevel(0); // -Infinity dB
+      master.changeFaderLevelDB(3);
+
+      expect(await firstValueFrom(master.faderLevelDB$)).toBe(-97);
+      expect(await firstValueFrom(master.faderLevel$)).not.toBe(0);
+    });
+  });
 });

--- a/packages/mixer-connection/src/lib/facade/master-bus.ts
+++ b/packages/mixer-connection/src/lib/facade/master-bus.ts
@@ -166,7 +166,9 @@ export class MasterBus implements FadeableChannel, PannableChannel {
    * @param offsetDB value (dB) to add to the current value
    */
   changeFaderLevelDB(offsetDB: number) {
-    this.faderLevelDB$.pipe(take(1)).subscribe(v => this.setFaderLevelDB(v + offsetDB));
+    this.faderLevelDB$
+      .pipe(take(1))
+      .subscribe(v => this.setFaderLevelDB(Math.max(v, -100) + offsetDB));
   }
 
   /**

--- a/packages/mixer-connection/src/lib/facade/volume-bus.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/volume-bus.spec.ts
@@ -48,6 +48,14 @@ describe('Volume Bus', () => {
       bus.changeFaderLevelDB(-6);
       expect(await firstValueFrom(bus.faderLevelDB$)).toBe(-15);
     });
+
+    it('should change level from -Infinity dB upwards', async () => {
+      bus.setFaderLevel(0); // -Infinity dB
+      bus.changeFaderLevelDB(3);
+
+      expect(await firstValueFrom(bus.faderLevelDB$)).toBe(-97);
+      expect(await firstValueFrom(bus.faderLevel$)).not.toBe(0);
+    });
   });
 
   describe('Fades', () => {

--- a/packages/mixer-connection/src/lib/facade/volume-bus.ts
+++ b/packages/mixer-connection/src/lib/facade/volume-bus.ts
@@ -100,6 +100,8 @@ export class VolumeBus implements FadeableChannel {
    * @param offsetDB value (dB) to add to the current value
    */
   changeFaderLevelDB(offsetDB: number) {
-    this.faderLevelDB$.pipe(take(1)).subscribe(v => this.setFaderLevelDB(v + offsetDB));
+    this.faderLevelDB$
+      .pipe(take(1))
+      .subscribe(v => this.setFaderLevelDB(Math.max(v, -100) + offsetDB));
   }
 }


### PR DESCRIPTION
Adding dB values to -Infinity dB resulted in no change. This was fixed by assuming -100 dB as the minimum value for calculation.