### PR TITLE
feat: add start and stop for multi-track recording

### DIFF
--- a/packages/mixer-connection/README.md
+++ b/packages/mixer-connection/README.md
@@ -419,6 +419,8 @@ It supports the following operations:
 | `pause()`                   | Pause                                                                                                                                         |
 | `stop()`                    | Stop                                                                                                                                          |
 | `recordToggle()`            | Toggle recording                                                                                                                              |
+| `recordStart()`             | Start recording                                                                                                                               |
+| `recordStop()`              | Stop recording                                                                                                                                |
 | `activateSoundcheck()`      | Activate soundcheck                                                                                                                           |
 | `deactivateSoundcheck()`    | Deactivate soundcheck                                                                                                                         |
 | `toggleSoundcheck()`        | Toggle soundcheck                                                                                                                             |

--- a/packages/mixer-connection/src/lib/facade/multi-track-recorder.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/multi-track-recorder.spec.ts
@@ -1,4 +1,4 @@
-import { firstValueFrom } from 'rxjs';
+import { firstValueFrom, of } from 'rxjs';
 import { SoundcraftUI } from '../soundcraft-ui';
 import { MtkState } from '../types';
 import { MultiTrackRecorder } from './multi-track-recorder';
@@ -113,6 +113,40 @@ describe('Multi-track recorder', () => {
 
       mtk.toggleSoundcheck();
       expect(await firstValueFrom(mtk.soundcheck$)).toBe(0);
+    });
+  });
+
+  describe('Recording Start/Stop', () => {
+    beforeEach(() => {
+      conn.conn.sendMessage = jest.fn();
+    });
+
+    it('recordStart should toggle when stopped', () => {
+      mtk.recording$ = of(0); // stopped;
+      mtk.recordStart();
+
+      expect(conn.conn.sendMessage).toHaveBeenCalledWith('MTK_REC_TOGGLE');
+    });
+
+    it('recordStart should not toggle when recording', () => {
+      mtk.recording$ = of(1); // recording;
+      mtk.recordStart();
+
+      expect(conn.conn.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('recordStop should toggle when recording', () => {
+      mtk.recording$ = of(1); // recording;
+      mtk.recordStop();
+
+      expect(conn.conn.sendMessage).toHaveBeenCalledWith('MTK_REC_TOGGLE');
+    });
+
+    it('recordStop should not toggle when stopped', () => {
+      mtk.recording$ = of(0); // stopped;
+      mtk.recordStop();
+
+      expect(conn.conn.sendMessage).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/mixer-connection/src/lib/facade/multi-track-recorder.ts
+++ b/packages/mixer-connection/src/lib/facade/multi-track-recorder.ts
@@ -79,6 +79,26 @@ export class MultiTrackRecorder {
     this.conn.sendMessage('MTK_REC_TOGGLE');
   }
 
+  /** Start recording */
+  recordStart() {
+    this.recording$.pipe(take(1)).subscribe(recording => {
+      // to start recording we have to make sure recording is stopped so that toggling will start it
+      if (!recording) {
+        this.recordToggle();
+      }
+    });
+  }
+
+  /** Stop recording */
+  recordStop() {
+    this.recording$.pipe(take(1)).subscribe(recording => {
+      // to stop recording we have to make sure recording is running so that toggling will stop it
+      if (recording) {
+        this.recordToggle();
+      }
+    });
+  }
+
   /**
    * Set soundcheck (activate or deactivate)
    * @param value `0` or `1`

--- a/packages/testbed/src/app/pages/multitrack/multitrack.component.html
+++ b/packages/testbed/src/app/pages/multitrack/multitrack.component.html
@@ -16,6 +16,8 @@
   <sui-mixer-button (press)="mtk.recordToggle()" [active]="!!(mtk.recording$ | async)">
     REC
   </sui-mixer-button>
+  <sui-mixer-button (press)="mtk.recordStart()">REC Start</sui-mixer-button>
+  <sui-mixer-button (press)="mtk.recordStop()">REC Stop</sui-mixer-button>
 </div>
 
 <div class="mb-3">


### PR DESCRIPTION
These are convenience functions to make things easier from the user perspective. They take the current recording state into account and toggle accordingly.