### PR TITLE
feat: wait for initial params after connection init

### DIFF
--- a/packages/mixer-connection/src/lib/soundcraft-ui.ts
+++ b/packages/mixer-connection/src/lib/soundcraft-ui.ts
@@ -16,6 +16,7 @@ import { MixerConnection } from './mixer-connection';
 import { MixerStore } from './state/mixer-store';
 import { ConnectionEvent, SoundcraftUIOptions } from './types';
 import { VuProcessor } from './vu/vu-processor';
+import { waitForInitParams } from './utils';
 
 export class SoundcraftUI {
   private _options: SoundcraftUIOptions;
@@ -138,9 +139,10 @@ export class SoundcraftUI {
     return new HwChannel(this.conn, this.store, this.deviceInfo, channel);
   }
 
-  /** Connect to the mixer. Returns a Promise that resolves when the connection is open. */
-  connect(): Promise<void> {
-    return this.conn.connect();
+  /** Connect to the mixer. Returns a Promise that resolves when the connection is open and the initial params have likely been received by the mixer. */
+  async connect(): Promise<void> {
+    await this.conn.connect();
+    await waitForInitParams(this.store);
   }
 
   /** Disconnect from the mixer. Returns a Promise that resolves when the connection is closed. */
@@ -150,9 +152,10 @@ export class SoundcraftUI {
 
   /**
    * Reconnect to the mixer after 1 second.
-   * Returns a Promise that resolves when the connection is open again.
+   * Returns a Promise that resolves when the connection is open again and the initial params have likely been received by the mixer.
    */
-  reconnect(): Promise<void> {
-    return this.conn.reconnect();
+  async reconnect(): Promise<void> {
+    await this.conn.reconnect();
+    await waitForInitParams(this.store);
   }
 }

--- a/packages/mixer-connection/src/lib/utils.ts
+++ b/packages/mixer-connection/src/lib/utils.ts
@@ -1,3 +1,5 @@
+import { debounceTime, firstValueFrom, race, take, timer } from 'rxjs';
+import { MixerStore } from './state/mixer-store';
 import { ChannelType, FxType } from './types';
 
 /** Clamp numeric value to min and max */
@@ -96,4 +98,13 @@ export function constructReadableChannelName(type: ChannelType, channel: number)
     case 'p':
       return 'PLAYER ' + numberToLR(channel);
   }
+}
+
+/**
+ * Returns a Promise that fires when the mixer state hasn't changed for 25 ms OR when 250 ms timeout are over.
+ * This makes sure that all initial params can be received by the mixer after connection init.
+ * In case the state never stands still for 50 ms, the 250 ms timeout will emit finally.
+ */
+export function waitForInitParams(store: MixerStore): Promise<void> {
+  return firstValueFrom(race(store.state$.pipe(debounceTime(25)), timer(250)));
 }


### PR DESCRIPTION
After connection init, the mixer sends all current state params to the client. Commands that depend on state, e.g. "toggle mute", cannot be reliably executed before all state is present.
We now wait until the state hasn't changed for a while which indicates that all ~5000 params have been received. In case the state changes for a longer time, we also have a timeout that ends the connection process.