### PR TITLE
ci: dependabot and Nx Cloud

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,10 @@ updates:
     commit-message:
       prefix: 'deps'
     ignore:
+      # these deps are managed by nx
       - dependency-name: '@angular/*'
       - dependency-name: '@angular-devkit/*'
       - dependency-name: '@schematics/angular'
+      - dependency-name: 'nx'
+      - dependency-name: 'eslint'
       - dependency-name: '@nx/*'

--- a/.github/workflows/ci-nx.yml
+++ b/.github/workflows/ci-nx.yml
@@ -1,9 +1,9 @@
-name: CI Build and test
+name: CI Build and test (Nx Cloud)
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  # push:
+  #   branches:
+  #     - main
+  # pull_request:
   workflow_dispatch:
 
 # Needed for nx-set-shas when run on the main branch
@@ -14,8 +14,6 @@ permissions:
 jobs:
   main:
     runs-on: ubuntu-latest
-    env:
-      NX_NO_CLOUD: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -24,7 +22,10 @@ jobs:
         with:
           node-version: 22
           cache: 'npm'
+      - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js"
       - run: npm ci
+
       - uses: nrwl/nx-set-shas@v4
-      - run: npx nx format:check
+
+      - run: npx nx-cloud record -- nx format:check
       - run: npx nx affected -t lint test build


### PR DESCRIPTION
We initially used Nx Cloud because the marketing was good.
    Remote execution and distrubuted caching are great features for large-scale
    projects. However, with a lot of Pull Requests by Dependabot and hence execution time,
    the free token budget was often exceeded. For this small project we do not actually
    benefit from Nx Cloud, so we now run the workflow directly through GitHub Actions.