### PR TITLE
feat: PostProcessableChannel interface + postProc$ observable

### DIFF
--- a/docs/docs/buses/aux-sends.md
+++ b/docs/docs/buses/aux-sends.md
@@ -29,6 +29,7 @@ An `AuxChannel` supports the following operations:
 | `postProc()`                     | Set channel to POST PROC                                              |
 | `setPostProc(value)`             | Set POST PROC (`1`) or PRE PROC (`0`)                                 |
 | `post$`                          | Get POST status (`0` for PRE, `1` for POST)                           |
+| `postProc$`                      | Get POST PROC status (`0` for PRE PROC, `1` for POST PROC)            |
 | `pan$`                           | Get pan value (between `0` and `1`)                                   |
 
 On the Ui24R an AUX bus can be converted into a matrix bus.

--- a/docs/docs/buses/matrix.md
+++ b/docs/docs/buses/matrix.md
@@ -71,6 +71,7 @@ A channel supports the following operations:
 | `postProc()`                     | Set channel to POST PROC                                              |
 | `setPostProc(value)`             | Set POST PROC (`1`) or PRE PROC (`0`)                                 |
 | `pan$`                           | Get pan value (between `0` and `1`)                                   |
+| `postProc$`                      | Get POST PROC status (`0` for PRE PROC, `1` for POST PROC)            |
 
 :::note
 The master source (`MtxMasterChannel`) has a static name: `name$` always emits `MASTER` and there is no `setName()`.

--- a/packages/mixer-connection/src/lib/facade/aux-channel.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/aux-channel.spec.ts
@@ -69,4 +69,17 @@ describe('AUX Channel', () => {
       expect(await firstValueFrom(channel.post$)).toBe(0);
     });
   });
+
+  describe('PRE/POST PROC', () => {
+    it('postProc$', async () => {
+      channel.postProc();
+      expect(await firstValueFrom(channel.postProc$)).toBe(1);
+
+      channel.preProc();
+      expect(await firstValueFrom(channel.postProc$)).toBe(0);
+
+      channel.setPostProc(1);
+      expect(await firstValueFrom(channel.postProc$)).toBe(1);
+    });
+  });
 });

--- a/packages/mixer-connection/src/lib/facade/aux-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/aux-channel.ts
@@ -1,23 +1,28 @@
 import { combineLatest, map, take } from 'rxjs';
 import { MixerConnection } from '../mixer-connection';
 import { MixerStore } from '../state/mixer-store';
-import { select, selectPan, selectStereoIndex } from '../state/state-selectors';
+import { select, selectPan, selectPostProc, selectStereoIndex } from '../state/state-selectors';
 import { ChannelType } from '../types';
 import { clamp, getLinkedChannelNumber, roundToThreeDecimals } from '../utils';
 import { constructSendChannelId } from './channel-id';
-import { PannableChannel } from './interfaces';
+import { PannableChannel, PostProcessableChannel } from './interfaces';
 import { SendChannel } from './send-channel';
 
 /**
  * Represents a channel on an AUX bus
  */
-export class AuxChannel extends SendChannel implements PannableChannel {
+export class AuxChannel extends SendChannel implements PannableChannel, PostProcessableChannel {
   /** when the AUX bus is stereo-linked, this contains the ID of this channel on the linked bus */
   private auxLinkChannelIds: string[] = [];
 
   /** PAN value of the AUX channel (between `0` and `1`) */
   pan$ = this.store.state$.pipe(
     select(selectPan(this.channelType, this.channel, this.busType, this.bus)),
+  );
+
+  /** PRE/POST PROC value of the AUX channel (`1` (POST PROC) or `0` (PRE PROC)) */
+  postProc$ = this.store.state$.pipe(
+    select(selectPostProc(this.channelType, this.channel, this.busType, this.bus)),
   );
 
   constructor(

--- a/packages/mixer-connection/src/lib/facade/interfaces.ts
+++ b/packages/mixer-connection/src/lib/facade/interfaces.ts
@@ -25,3 +25,12 @@ export interface PannableChannel {
   setPan(value: number): void;
   changePan(offset: number): void;
 }
+
+export interface PostProcessableChannel {
+  /** PRE/POST PROC value of the channel (`1` (POST PROC) or `0` (PRE PROC)) */
+  postProc$: Observable<number>;
+
+  setPostProc(value: number): void;
+  postProc(): void;
+  preProc(): void;
+}

--- a/packages/mixer-connection/src/lib/facade/mtx-bus-channel.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/mtx-bus-channel.spec.ts
@@ -91,6 +91,19 @@ describe('MTX Bus Channel', () => {
     });
   });
 
+  describe('PRE/POST PROC', () => {
+    it('postProc$', async () => {
+      channel.postProc();
+      expect(await firstValueFrom(channel.postProc$)).toBe(1);
+
+      channel.preProc();
+      expect(await firstValueFrom(channel.postProc$)).toBe(0);
+
+      channel.setPostProc(1);
+      expect(await firstValueFrom(channel.postProc$)).toBe(1);
+    });
+  });
+
   describe('name$', () => {
     it('should return the default name for an AUX source', async () => {
       // a matrix source is always a regular AUX/subgroup (a matrix cannot be routed into a matrix)

--- a/packages/mixer-connection/src/lib/facade/mtx-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/mtx-channel.ts
@@ -8,7 +8,7 @@ import { clamp, roundToThreeDecimals } from '../utils';
 import { resolveDelayed } from '../utils/async-helpers';
 import { Easings } from '../utils/transitions/easings';
 import { DBToFaderValue, faderValueToDB } from '../utils/value-converters';
-import { FadeableChannel, PannableChannel } from './interfaces';
+import { FadeableChannel, PannableChannel, PostProcessableChannel } from './interfaces';
 
 /**
  * Base class for all sources routed to a matrix bus.
@@ -21,7 +21,9 @@ import { FadeableChannel, PannableChannel } from './interfaces';
  * which is the one source that can't be derived from the id (the master source has no
  * channel index and therefore no name path).
  */
-export abstract class MtxChannel implements FadeableChannel, PannableChannel {
+export abstract class MtxChannel
+  implements FadeableChannel, PannableChannel, PostProcessableChannel
+{
   /** Name of the matrix source (provided by the concrete subclass) */
   abstract readonly name$: Observable<string>;
 
@@ -38,6 +40,11 @@ export abstract class MtxChannel implements FadeableChannel, PannableChannel {
 
   /** PAN value of the matrix source (between `0` and `1`) */
   readonly pan$ = this.store.state$.pipe(selectRawValue<number>(`${this.fullChannelId}.pan`, 0));
+
+  /** PRE/POST PROC value of the matrix source (`1` (POST PROC) or `0` (PRE PROC)) */
+  readonly postProc$ = this.store.state$.pipe(
+    selectRawValue<number>(`${this.fullChannelId}.postproc`, 0),
+  );
 
   /** all linked channels (mirror on the stereo-linked matrix output and stereo-link neighbour) */
   protected linkedChannelIds: string[] = [];

--- a/packages/mixer-connection/src/lib/facade/mtx-master-channel.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/mtx-master-channel.spec.ts
@@ -84,4 +84,17 @@ describe('MTX Master Channel', () => {
       expect(await firstValueFrom(channel.pan$)).toBe(0.686);
     });
   });
+
+  describe('PRE/POST PROC', () => {
+    it('postProc$', async () => {
+      channel.postProc();
+      expect(await firstValueFrom(channel.postProc$)).toBe(1);
+
+      channel.preProc();
+      expect(await firstValueFrom(channel.postProc$)).toBe(0);
+
+      channel.setPostProc(1);
+      expect(await firstValueFrom(channel.postProc$)).toBe(1);
+    });
+  });
 });

--- a/packages/mixer-connection/src/lib/state/state-selectors.spec.ts
+++ b/packages/mixer-connection/src/lib/state/state-selectors.spec.ts
@@ -14,7 +14,7 @@ import {
   selectFaderValue,
   selectDelayValue,
   selectPost,
-  selectAuxPostProc,
+  selectPostProc,
   selectFxBpm,
   selectFxType,
   selectStereoIndex,
@@ -220,14 +220,19 @@ describe('State Selectors', () => {
     });
   });
 
-  describe('selectAuxPostProc', () => {
+  describe('selectPostProc', () => {
     it('should read postproc value for an aux send', () => {
-      const projector = selectAuxPostProc('i', 4, 2);
+      const projector = selectPostProc('i', 4, 'aux', 2);
       expect(projector({ 'i.3.aux.1.postproc': 1 })).toBe(1);
     });
 
+    it('should read postproc value for a matrix send', () => {
+      const projector = selectPostProc('a', 1, 'mtx', 7);
+      expect(projector({ 'a.0.mtx.6.postproc': 1 })).toBe(1);
+    });
+
     it('should default to 0', () => {
-      const projector = selectAuxPostProc('i', 4, 2);
+      const projector = selectPostProc('i', 4, 'aux', 2);
       expect(projector({})).toBe(0);
     });
   });

--- a/packages/mixer-connection/src/lib/state/state-selectors.ts
+++ b/packages/mixer-connection/src/lib/state/state-selectors.ts
@@ -179,15 +179,15 @@ export const selectPost: Selector<number> = (
  * Select "postproc" value of a send channel
  * @param channelType
  * @param channel
+ * @param busType
+ * @param bus
  */
-export const selectAuxPostProc: Selector<number> = (
+export const selectPostProc: Selector<number> = (
   channelType: ChannelType,
   channel: number,
-  aux: number,
-) => {
-  const path = joinStatePath(channelType, channel - 1, 'aux', aux - 1, 'postproc');
-  return state => getValueFromObject(state, path, 0);
-};
+  busType: BusType,
+  bus?: number,
+) => selectGenericChannelProperty('postproc', 0, channelType, channel, busType, bus);
 
 /**
  * Select BPM value of an FX bus

--- a/packages/testbed/src/app/pages/aux-bus-page/aux-bus-page.html
+++ b/packages/testbed/src/app/pages/aux-bus-page/aux-bus-page.html
@@ -7,11 +7,7 @@
 <h2 class="mt-4">{{ c.label }} ({{ c.channel.name$ | async }})</h2>
 <sui-mute-button [channel]="c.channel" />
 <sui-prepost-controls [channel]="c.channel" />
-<!-- POST/PRE PROC -->
-<div>
-  <sui-mixer-button (press)="c.channel.preProc()"> PRE PROC</sui-mixer-button>
-  <sui-mixer-button (press)="c.channel.postProc()">POST PROC</sui-mixer-button>
-</div>
+<sui-postproc-controls class="ms-3" [channel]="c.channel" />
 <sui-fader-level-controls [channel]="c.channel" />
 <sui-pan-controls [channel]="c.channel" />
 <sui-transition-controls [channel]="c.channel" />

--- a/packages/testbed/src/app/pages/aux-bus-page/aux-bus-page.ts
+++ b/packages/testbed/src/app/pages/aux-bus-page/aux-bus-page.ts
@@ -6,7 +6,7 @@ import { AsyncPipe } from '@angular/common';
 import { ConnectionService } from '../../connection.service';
 import { MuteButton } from '../../ui/mute-button/mute-button';
 import { PrepostControls } from '../../ui/prepost-controls/prepost-controls';
-import { MixerButton } from '../../ui/mixer-button/mixer-button';
+import { PostprocControls } from '../../ui/postproc-controls/postproc-controls';
 import { FaderLevelControls } from '../../ui/fader-level-controls/fader-level-controls';
 import { PanControls } from '../../ui/pan-controls/pan-controls';
 import { TransitionControls } from '../../ui/transition-controls/transition-controls';
@@ -19,7 +19,7 @@ import { InputField } from '../../ui/input-field/input-field';
     AsyncPipe,
     MuteButton,
     PrepostControls,
-    MixerButton,
+    PostprocControls,
     FaderLevelControls,
     PanControls,
     TransitionControls,

--- a/packages/testbed/src/app/pages/mtx-bus-page/mtx-bus-page.html
+++ b/packages/testbed/src/app/pages/mtx-bus-page/mtx-bus-page.html
@@ -39,11 +39,7 @@
 <sui-mixer-button [active]="(s.channel.mute$ | async) === 1" (press)="s.channel.toggleMute()">
   MUTE
 </sui-mixer-button>
-<!-- POST/PRE PROC -->
-<div>
-  <sui-mixer-button (press)="s.channel.preProc()">PRE PROC</sui-mixer-button>
-  <sui-mixer-button (press)="s.channel.postProc()">POST PROC</sui-mixer-button>
-</div>
+<sui-postproc-controls [channel]="s.channel" />
 <sui-fader-level-controls [channel]="s.channel" />
 <sui-pan-controls [channel]="s.channel" />
 <sui-transition-controls [channel]="s.channel" />

--- a/packages/testbed/src/app/pages/mtx-bus-page/mtx-bus-page.ts
+++ b/packages/testbed/src/app/pages/mtx-bus-page/mtx-bus-page.ts
@@ -11,6 +11,7 @@ import { InputField } from '../../ui/input-field/input-field';
 import { MixerButton } from '../../ui/mixer-button/mixer-button';
 import { MuteButton } from '../../ui/mute-button/mute-button';
 import { PanControls } from '../../ui/pan-controls/pan-controls';
+import { PostprocControls } from '../../ui/postproc-controls/postproc-controls';
 import { SoloButton } from '../../ui/solo-button/solo-button';
 import { TransitionControls } from '../../ui/transition-controls/transition-controls';
 
@@ -23,6 +24,7 @@ import { TransitionControls } from '../../ui/transition-controls/transition-cont
     MuteButton,
     SoloButton,
     PanControls,
+    PostprocControls,
     FaderLevelControls,
     TransitionControls,
     DelayControls,

--- a/packages/testbed/src/app/ui/mixer-button/mixer-button.scss
+++ b/packages/testbed/src/app/ui/mixer-button/mixer-button.scss
@@ -59,4 +59,13 @@ button {
       background: color.adjust(#069840, $lightness: 5%);
     }
   }
+
+  &.preproc {
+    color: white;
+    background: #e8590c;
+
+    &:hover {
+      background: color.adjust(#e8590c, $lightness: 10%);
+    }
+  }
 }

--- a/packages/testbed/src/app/ui/postproc-controls/postproc-controls.html
+++ b/packages/testbed/src/app/ui/postproc-controls/postproc-controls.html
@@ -1,0 +1,3 @@
+<sui-mixer-button activeClass="preproc" [active]="!postProc()" (press)="toggle()">
+  {{ postProc() ? 'POST PROC' : 'PRE PROC' }}
+</sui-mixer-button>

--- a/packages/testbed/src/app/ui/postproc-controls/postproc-controls.ts
+++ b/packages/testbed/src/app/ui/postproc-controls/postproc-controls.ts
@@ -1,0 +1,30 @@
+import { toSignal, toObservable } from '@angular/core/rxjs-interop';
+import { Component, input } from '@angular/core';
+import { map, switchMap } from 'rxjs';
+import { PostProcessableChannel } from 'soundcraft-ui-connection';
+import { MixerButton } from '../mixer-button/mixer-button';
+
+@Component({
+  selector: 'sui-postproc-controls',
+  templateUrl: './postproc-controls.html',
+  imports: [MixerButton],
+})
+export class PostprocControls {
+  readonly channel = input.required<PostProcessableChannel>();
+
+  readonly postProc = toSignal(
+    toObservable(this.channel).pipe(
+      switchMap(channel => channel.postProc$),
+      map(e => !!e),
+    ),
+    { initialValue: false },
+  );
+
+  toggle() {
+    if (this.postProc()) {
+      this.channel().preProc();
+    } else {
+      this.channel().postProc();
+    }
+  }
+}


### PR DESCRIPTION
- [ ] testing on real hardware

Builds on top of #300 (targets the `feat/matrix-bus-support` branch, not `main`).

Adds a shared postproc abstraction mirroring the existing `PannableChannel`/`FadeableChannel` pattern, in three commits:

1. **feat: add `postProc$` observable** — expose the current PRE/POST PROC state reactively on `AuxChannel`, `MtxChannel`, `MtxMasterChannel`; generalize the previously-unused postproc selector to `selectPostProc(channelType, channel, busType, bus)`; document `postProc$` in the AUX and Matrix bus docs.
2. **feat: add `PostProcessableChannel` interface** — `postProc$` / `setPostProc` / `postProc` / `preProc`, implemented by the three channel classes.
3. **feat(testbed): add `postproc-controls` component** — a reusable component typed by the interface: a single PRE/POST PROC toggle button whose label reflects the current state and that turns orange (new `mixer-button` `preproc` class) when in PRE PROC. Replaces the duplicated inline buttons on the AUX and MTX pages.

## Testing
- `nx test mixer-connection` — green (new `postProc$` round-trips + updated selector tests).
- `nx build` (mixer-connection + testbed), `nx lint`, `nx format:check` — all clean.

> Note: depends on #300; merge that first (or merge this into that branch).