### PR TITLE
feat: cache AuxBus instances and fix PannableChannel/linked channel

### DIFF
--- a/packages/mixer-connection/src/lib/__tests__/channel-singletons.spec.ts
+++ b/packages/mixer-connection/src/lib/__tests__/channel-singletons.spec.ts
@@ -59,5 +59,11 @@ describe('Object Store Singletons', () => {
       const obj2 = conn.fx(3);
       expect(obj1 === obj2).toBe(true);
     });
+
+    it('AuxBus', () => {
+      const obj1 = conn.aux(2);
+      const obj2 = conn.aux(2);
+      expect(obj1 === obj2).toBe(true);
+    });
   });
 });

--- a/packages/mixer-connection/src/lib/facade/aux-bus.ts
+++ b/packages/mixer-connection/src/lib/facade/aux-bus.ts
@@ -6,7 +6,20 @@ import { AuxChannel } from './aux-channel';
  * Represents an AUX bus
  */
 export class AuxBus {
-  constructor(private conn: MixerConnection, private store: MixerStore, private bus: number) {}
+  constructor(
+    private conn: MixerConnection,
+    private store: MixerStore,
+    private bus: number,
+  ) {
+    // lookup object in the store and use existing object if possible
+    const storeId = 'auxbus' + bus;
+    const storedObject = this.store.objectStore.get<AuxBus>(storeId);
+    if (storedObject) {
+      return storedObject;
+    } else {
+      this.store.objectStore.set(storeId, this);
+    }
+  }
 
   /**
    * Get input channel on the AUX bus

--- a/packages/mixer-connection/src/lib/facade/interfaces.ts
+++ b/packages/mixer-connection/src/lib/facade/interfaces.ts
@@ -23,4 +23,5 @@ export interface PannableChannel {
   pan$: Observable<number>;
 
   setPan(value: number): void;
+  changePan(offset: number): void;
 }

--- a/packages/mixer-connection/src/lib/utils.spec.ts
+++ b/packages/mixer-connection/src/lib/utils.spec.ts
@@ -3,12 +3,27 @@ import {
   clamp,
   constructReadableChannelName,
   fxTypeToString,
+  getLinkedChannelNumber,
   playerTimeToString,
   roundToThreeDecimals,
   transformStringValue,
 } from './utils';
 
 describe('utils', () => {
+  describe('getLinkedChannelNumber', () => {
+    it('should return the previous channel when this channel is second in the link', () => {
+      expect(getLinkedChannelNumber(4, 1)).toBe(3);
+    });
+
+    it('should return the next channel when this channel is first in the link', () => {
+      expect(getLinkedChannelNumber(4, 0)).toBe(5);
+    });
+
+    it('should return undefined when the channel is not linked', () => {
+      expect(getLinkedChannelNumber(4, -1)).toBeUndefined();
+    });
+  });
+
   describe('clamp', () => {
     it('should leave in-range values unchanged', () => {
       expect(clamp(400, 0, 500)).toBe(400);

--- a/packages/mixer-connection/src/lib/utils.ts
+++ b/packages/mixer-connection/src/lib/utils.ts
@@ -40,14 +40,21 @@ export function playerTimeToString(value: number) {
   return `${minutes}:${seconds.toString().length === 1 ? '0' : ''}${seconds}`;
 }
 
-export function getLinkedChannelNumber(channel: number, stereoIndex: number): number {
+/**
+ * Get the number of the channel that is stereo-linked to the given channel.
+ * Returns `undefined` when the channel is not linked (stereo index `-1`),
+ * so callers can skip adding a linked channel in that case.
+ * @param channel Channel number
+ * @param stereoIndex Stereo index of the channel (`0` = first, `1` = second, `-1` = not linked)
+ */
+export function getLinkedChannelNumber(channel: number, stereoIndex: number): number | undefined {
   switch (stereoIndex) {
     case 1:
       return channel - 1;
     case 0:
       return channel + 1;
     default:
-      return channel;
+      return undefined;
   }
 }
 
@@ -88,7 +95,7 @@ export function fxTypeToString(type: FxType): keyof typeof FxType {
  */
 export function constructReadableChannelName(
   type: ChannelType | VolumeBusType,
-  channel: number
+  channel: number,
 ): string {
   switch (type) {
     case 'i':

--- a/packages/testbed/src/app/ui/pan-controls/pan-controls.ts
+++ b/packages/testbed/src/app/ui/pan-controls/pan-controls.ts
@@ -1,6 +1,6 @@
 import { AsyncPipe } from '@angular/common';
 import { Component, input } from '@angular/core';
-import { AuxChannel, MasterBus, MasterChannel } from 'soundcraft-ui-connection';
+import { PannableChannel } from 'soundcraft-ui-connection';
 
 @Component({
   selector: 'sui-pan-controls',
@@ -9,7 +9,7 @@ import { AuxChannel, MasterBus, MasterChannel } from 'soundcraft-ui-connection';
   imports: [AsyncPipe],
 })
 export class PanControls {
-  readonly channel = input.required<MasterChannel | AuxChannel | MasterBus>();
+  readonly channel = input.required<PannableChannel>();
 
   setPan(value: string) {
     this.channel().setPan(Number(value));


### PR DESCRIPTION
Splits preparatory changes out of the MTX feature PR (#300) so they can be merged first.

## Commits
- **feat: cache AuxBus instances in the object store** (`4c5f95b`)
- **fix: add changePan to PannableChannel interface** (`781e9ab`)
- **fix: return undefined from getLinkedChannelNumber when not linked** (`3d5579f`)

The MTX feature (#300) is stacked on top of this branch and should be merged after this one.