### PR TITLE
refactor: extract channel id construction into shared helper functions

### DIFF
--- a/packages/mixer-connection/src/lib/facade/aux-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/aux-channel.ts
@@ -4,6 +4,7 @@ import { MixerStore } from '../state/mixer-store';
 import { select, selectPan, selectStereoIndex } from '../state/state-selectors';
 import { ChannelType } from '../types';
 import { clamp, getLinkedChannelNumber, roundToThreeDecimals } from '../utils';
+import { constructSendChannelId } from './channel-id';
 import { PannableChannel } from './interfaces';
 import { SendChannel } from './send-channel';
 
@@ -16,7 +17,7 @@ export class AuxChannel extends SendChannel implements PannableChannel {
 
   /** PAN value of the AUX channel (between `0` and `1`) */
   pan$ = this.store.state$.pipe(
-    select(selectPan(this.channelType, this.channel, this.busType, this.bus))
+    select(selectPan(this.channelType, this.channel, this.busType, this.bus)),
   );
 
   constructor(
@@ -24,7 +25,7 @@ export class AuxChannel extends SendChannel implements PannableChannel {
     store: MixerStore,
     channelType: ChannelType,
     channel: number,
-    bus: number
+    bus: number,
   ) {
     super(conn, store, channelType, channel, 'aux', bus);
 
@@ -45,12 +46,12 @@ export class AuxChannel extends SendChannel implements PannableChannel {
 
           // add linked channel on this bus
           if (linkedChNo !== undefined) {
-            allChannelIds.push(this.constructChannelId(channelType, linkedChNo, this.busType, bus));
+            allChannelIds.push(constructSendChannelId(channelType, linkedChNo, this.busType, bus));
           }
 
           // add this channel on linked AUX bus
           if (linkedAuxNo !== undefined) {
-            const cid = this.constructChannelId(channelType, channel, this.busType, linkedAuxNo);
+            const cid = constructSendChannelId(channelType, channel, this.busType, linkedAuxNo);
             allChannelIds.push(cid);
             auxLinkChannelIds.push(cid);
           }
@@ -58,11 +59,11 @@ export class AuxChannel extends SendChannel implements PannableChannel {
           // add linked channel on linked AUX bus
           if (linkedAuxNo !== undefined && linkedChNo !== undefined) {
             allChannelIds.push(
-              this.constructChannelId(channelType, linkedChNo, this.busType, linkedAuxNo)
+              constructSendChannelId(channelType, linkedChNo, this.busType, linkedAuxNo),
             );
           }
           return { allChannelIds, auxLinkChannelIds };
-        })
+        }),
       )
       .subscribe(result => {
         this.linkedChannelIds = result.allChannelIds;

--- a/packages/mixer-connection/src/lib/facade/channel-id.ts
+++ b/packages/mixer-connection/src/lib/facade/channel-id.ts
@@ -1,0 +1,16 @@
+import { BusType, ChannelType } from '../types';
+
+/** construct the channel id for a master channel, e.g. `i.0` */
+export function constructMasterChannelId(channelType: ChannelType, channel: number) {
+  return `${channelType}.${channel - 1}`;
+}
+
+/** construct the channel id for a send (AUX/FX) channel, e.g. `i.0.aux.2` */
+export function constructSendChannelId(
+  channelType: ChannelType,
+  channel: number,
+  busType: BusType,
+  bus: number,
+) {
+  return `${channelType}.${channel - 1}.${busType}.${bus - 1}`;
+}

--- a/packages/mixer-connection/src/lib/facade/fx-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/fx-channel.ts
@@ -4,6 +4,7 @@ import { MixerConnection } from '../mixer-connection';
 import { MixerStore } from '../state/mixer-store';
 import { ChannelType } from '../types';
 import { getLinkedChannelNumber } from '../utils';
+import { constructSendChannelId } from './channel-id';
 import { SendChannel } from './send-channel';
 
 /**
@@ -15,7 +16,7 @@ export class FxChannel extends SendChannel {
     store: MixerStore,
     channelType: ChannelType,
     channel: number,
-    bus: number
+    bus: number,
   ) {
     super(conn, store, channelType, channel, 'fx', bus);
 
@@ -26,17 +27,12 @@ export class FxChannel extends SendChannel {
           const linkedChannelNumber = getLinkedChannelNumber(channel, index);
           if (linkedChannelNumber !== undefined) {
             return [
-              this.constructChannelId(
-                this.channelType,
-                linkedChannelNumber,
-                this.busType,
-                this.bus
-              ),
+              constructSendChannelId(this.channelType, linkedChannelNumber, this.busType, this.bus),
             ];
           } else {
             return [];
           }
-        })
+        }),
       )
       .subscribe(c => (this.linkedChannelIds = c));
   }

--- a/packages/mixer-connection/src/lib/facade/master-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/master-channel.ts
@@ -6,6 +6,7 @@ import { select, selectPan, selectRawValue, selectSolo } from '../state/state-se
 import { ChannelType } from '../types';
 import { clamp, getLinkedChannelNumber, roundToThreeDecimals } from '../utils';
 import { Channel } from './channel';
+import { constructMasterChannelId } from './channel-id';
 import { PannableChannel } from './interfaces';
 import { AutomixGroupId } from './automix-controller';
 import {
@@ -17,11 +18,7 @@ import {
  * Represents a channel on the master bus
  */
 export class MasterChannel extends Channel implements PannableChannel {
-  private constructChannelId(channelType: ChannelType, channel: number) {
-    return `${channelType}.${channel - 1}`;
-  }
-
-  override fullChannelId = this.constructChannelId(this.channelType, this.channel);
+  override fullChannelId = constructMasterChannelId(this.channelType, this.channel);
   override faderLevelCommand = 'mix';
 
   /** SOLO value of the channel (`0` or `1`) */
@@ -29,7 +26,7 @@ export class MasterChannel extends Channel implements PannableChannel {
 
   /** PAN value of the channel (between `0` and `1`) */
   pan$ = this.store.state$.pipe(
-    select(selectPan(this.channelType, this.channel, this.busType, this.bus))
+    select(selectPan(this.channelType, this.channel, this.busType, this.bus)),
   );
 
   /** Assigned automix group (`a`, `b`, `none`) */
@@ -44,7 +41,7 @@ export class MasterChannel extends Channel implements PannableChannel {
         default:
           return 'none';
       }
-    })
+    }),
   );
 
   /** Automix weight (linear) for this channel (between `0` and `1`) */
@@ -55,7 +52,7 @@ export class MasterChannel extends Channel implements PannableChannel {
 
   /** Multitrack selection state for the channel (`0` or `1`) */
   multiTrackSelected$ = this.store.state$.pipe(
-    selectRawValue<number>(`${this.fullChannelId}.mtkrec`)
+    selectRawValue<number>(`${this.fullChannelId}.mtkrec`),
   );
 
   constructor(conn: MixerConnection, store: MixerStore, channelType: ChannelType, channel: number) {
@@ -67,11 +64,11 @@ export class MasterChannel extends Channel implements PannableChannel {
         map(index => {
           const linkedChannelNumber = getLinkedChannelNumber(channel, index);
           if (linkedChannelNumber !== undefined) {
-            return [this.constructChannelId(this.channelType, linkedChannelNumber)];
+            return [constructMasterChannelId(this.channelType, linkedChannelNumber)];
           } else {
             return [];
           }
-        })
+        }),
       )
       .subscribe(c => (this.linkedChannelIds = c));
   }

--- a/packages/mixer-connection/src/lib/facade/send-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/send-channel.ts
@@ -5,32 +5,24 @@ import { MixerStore } from '../state/mixer-store';
 import { select, selectPost } from '../state/state-selectors';
 import { BusType, ChannelType } from '../types';
 import { Channel } from './channel';
+import { constructSendChannelId } from './channel-id';
 
 /**
  * Represents a channel on a send bus (AUX or FX).
  * Used as super class for Aux and Fx
  */
 export class SendChannel extends Channel {
-  protected constructChannelId(
-    channelType: ChannelType,
-    channel: number,
-    busType: BusType,
-    bus: number
-  ) {
-    return `${channelType}.${channel - 1}.${busType}.${bus - 1}`;
-  }
-
-  override fullChannelId = this.constructChannelId(
+  override fullChannelId = constructSendChannelId(
     this.channelType,
     this.channel,
     this.busType,
-    this.bus
+    this.bus,
   );
   override faderLevelCommand = 'value';
 
   /** PRE/POST value of the channel (`1` (POST) or `0` (PRE)) */
   post$ = this.store.state$.pipe(
-    select(selectPost(this.channelType, this.channel, this.busType, this.bus))
+    select(selectPost(this.channelType, this.channel, this.busType, this.bus)),
   );
 
   constructor(
@@ -39,7 +31,7 @@ export class SendChannel extends Channel {
     channelType: ChannelType,
     channel: number,
     busType: BusType,
-    bus: number
+    bus: number,
   ) {
     super(conn, store, channelType, channel, busType, bus);
   }


### PR DESCRIPTION
Preparatory refactor split out of the MTX feature PR (#300) so it can be merged first.

Replaces the per-class `constructChannelId` methods on `MasterChannel` and `SendChannel` with pure functions in a new **internal** `facade/channel-id.ts` module:

- `constructMasterChannelId(channelType, channel)` → `i.0`
- `constructSendChannelId(channelType, channel, busType, bus)` → `i.0.aux.2`

`AuxChannel` and `FxChannel` now import the shared function directly instead of inheriting a `protected` method. The module is intentionally **not** re-exported from the facade barrel, so it stays out of the public API.

The MTX feature (#300) is stacked on top of this branch and adds `constructMtxChannelId` to the same module.