### PR TITLE
refactor: split constructReadableChannelName into focused name helpers

### DIFF
--- a/packages/mixer-connection/src/lib/facade/channel.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/channel.spec.ts
@@ -191,7 +191,7 @@ describe('Channel', () => {
 
     describe('Channel Name', () => {
       describe('name$', () => {
-        it('should read name for master channels', async () => {
+        it('should read the set name (instead of the default) for master channels', async () => {
           conn.conn.sendMessage('SETS^i.3.name^TESTNAME');
           expect(await firstValueFrom(conn.master.input(4).name$)).toBe('TESTNAME');
 
@@ -206,6 +206,9 @@ describe('Channel', () => {
 
           conn.conn.sendMessage('SETS^a.4.name^AUXMASTER');
           expect(await firstValueFrom(conn.master.aux(5).name$)).toBe('AUXMASTER');
+
+          conn.conn.sendMessage('SETS^f.1.name^FXMASTER');
+          expect(await firstValueFrom(conn.master.fx(2).name$)).toBe('FXMASTER');
 
           conn.conn.sendMessage('SETS^v.1.name^THEVCA');
           expect(await firstValueFrom(conn.master.vca(2).name$)).toBe('THEVCA');
@@ -222,9 +225,31 @@ describe('Channel', () => {
           expect(await firstValueFrom(conn.aux(1).player(2).name$)).toBe('THEPLAYER');
         });
 
-        it('should return generic readable name (CH 6) when no name is set', async () => {
+        it('should return generic readable default name when no name is set', async () => {
           conn.conn.sendMessage('SETS^i.5.name^');
           expect(await firstValueFrom(conn.master.input(6).name$)).toBe('CH 6');
+
+          conn.conn.sendMessage('SETS^a.4.name^');
+          expect(await firstValueFrom(conn.master.aux(5).name$)).toBe('AUX 5');
+
+          conn.conn.sendMessage('SETS^f.2.name^');
+          expect(await firstValueFrom(conn.master.fx(3).name$)).toBe('FX 3');
+
+          conn.conn.sendMessage('SETS^s.3.name^');
+          expect(await firstValueFrom(conn.master.sub(4).name$)).toBe('SUB 4');
+
+          conn.conn.sendMessage('SETS^v.1.name^');
+          expect(await firstValueFrom(conn.master.vca(2).name$)).toBe('VCA 2');
+
+          conn.conn.sendMessage('SETS^l.0.name^');
+          expect(await firstValueFrom(conn.master.line(1).name$)).toBe('LINE IN L');
+          conn.conn.sendMessage('SETS^l.1.name^');
+          expect(await firstValueFrom(conn.master.line(2).name$)).toBe('LINE IN R');
+
+          conn.conn.sendMessage('SETS^p.0.name^');
+          expect(await firstValueFrom(conn.master.player(1).name$)).toBe('PLAYER L');
+          conn.conn.sendMessage('SETS^p.1.name^');
+          expect(await firstValueFrom(conn.master.player(2).name$)).toBe('PLAYER R');
         });
       });
 

--- a/packages/mixer-connection/src/lib/facade/channel.ts
+++ b/packages/mixer-connection/src/lib/facade/channel.ts
@@ -11,7 +11,7 @@ import {
 } from '../state/state-selectors';
 import { sourcesToTransition, TransitionSource } from '../transitions';
 import { BusType, ChannelType } from '../types';
-import { clamp, constructReadableChannelName, roundToThreeDecimals } from '../utils';
+import { clamp, getDefaultChannelName, roundToThreeDecimals } from '../utils';
 import { resolveDelayed } from '../utils/async-helpers';
 import { Easings } from '../utils/transitions/easings';
 import { DBToFaderValue, faderValueToDB } from '../utils/value-converters';
@@ -50,7 +50,7 @@ export class Channel implements FadeableChannel {
     // Channel name is only available directly in the channel, e.g. `i.1.name`.
     // `i.1.aux.2.name` will not work!
     selectRawValue<string>(joinStatePath(this.channelType, this.channel - 1, 'name')),
-    map(name => name || constructReadableChannelName(this.channelType, this.channel)),
+    map(name => name || getDefaultChannelName(this.channelType, this.channel)),
   );
 
   constructor(

--- a/packages/mixer-connection/src/lib/facade/volume-bus.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/volume-bus.spec.ts
@@ -18,6 +18,14 @@ describe('Volume Bus', () => {
     expect(obj1).toBe(obj2);
   });
 
+  describe('name$', () => {
+    it('should return the default volume bus name', async () => {
+      expect(await firstValueFrom(conn.volume.solo.name$)).toBe('SOLO LEVEL');
+      expect(await firstValueFrom(conn.volume.headphone(1).name$)).toBe('HEADPHONE 1 LEVEL');
+      expect(await firstValueFrom(conn.volume.headphone(2).name$)).toBe('HEADPHONE 2 LEVEL');
+    });
+  });
+
   describe('Fader Level', () => {
     it('faderLevel$', async () => {
       bus.setFaderLevel(0.5);

--- a/packages/mixer-connection/src/lib/facade/volume-bus.ts
+++ b/packages/mixer-connection/src/lib/facade/volume-bus.ts
@@ -3,7 +3,7 @@ import { MixerConnection } from '../mixer-connection';
 import { MixerStore } from '../state/mixer-store';
 import { select, selectVolumeBusValue } from '../state/state-selectors';
 import { sourcesToTransition, TransitionSource } from '../transitions';
-import { clamp, constructReadableChannelName, roundToThreeDecimals } from '../utils';
+import { clamp, getDefaultVolumeBusName, roundToThreeDecimals } from '../utils';
 import { resolveDelayed } from '../utils/async-helpers';
 import { Easings } from '../utils/transitions/easings';
 import { DBToFaderValue, faderValueToDB } from '../utils/value-converters';
@@ -24,7 +24,7 @@ export class VolumeBus implements FadeableChannel {
   /** dB level of the volume bus (between `-Infinity` and `10`) */
   faderLevelDB$ = this.faderLevel$.pipe(map(v => faderValueToDB(v)));
 
-  name$ = of(constructReadableChannelName(this.busName, this.busId || -1));
+  name$ = of(getDefaultVolumeBusName(this.busName, this.busId || -1));
 
   constructor(
     protected conn: MixerConnection,

--- a/packages/mixer-connection/src/lib/utils.spec.ts
+++ b/packages/mixer-connection/src/lib/utils.spec.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import {
   clamp,
-  constructReadableChannelName,
   fxTypeToString,
+  getDefaultChannelName,
+  getDefaultVolumeBusName,
   getLinkedChannelNumber,
   playerTimeToString,
   roundToThreeDecimals,
@@ -137,32 +138,36 @@ describe('utils', () => {
     });
   });
 
-  describe('constructReadableChannelName', () => {
+  describe('getDefaultChannelName', () => {
     it('should construct readable channel name', () => {
-      expect(constructReadableChannelName('i', 1)).toBe('CH 1');
-      expect(constructReadableChannelName('i', 2)).toBe('CH 2');
-      expect(constructReadableChannelName('i', 10)).toBe('CH 10');
+      expect(getDefaultChannelName('i', 1)).toBe('CH 1');
+      expect(getDefaultChannelName('i', 2)).toBe('CH 2');
+      expect(getDefaultChannelName('i', 10)).toBe('CH 10');
 
-      expect(constructReadableChannelName('a', 1)).toBe('AUX 1');
-      expect(constructReadableChannelName('a', 4)).toBe('AUX 4');
+      expect(getDefaultChannelName('a', 1)).toBe('AUX 1');
+      expect(getDefaultChannelName('a', 4)).toBe('AUX 4');
 
-      expect(constructReadableChannelName('f', 2)).toBe('FX 2');
-      expect(constructReadableChannelName('f', 3)).toBe('FX 3');
+      expect(getDefaultChannelName('f', 2)).toBe('FX 2');
+      expect(getDefaultChannelName('f', 3)).toBe('FX 3');
 
-      expect(constructReadableChannelName('s', 1)).toBe('SUB 1');
-      expect(constructReadableChannelName('s', 4)).toBe('SUB 4');
+      expect(getDefaultChannelName('s', 1)).toBe('SUB 1');
+      expect(getDefaultChannelName('s', 4)).toBe('SUB 4');
 
-      expect(constructReadableChannelName('v', 1)).toBe('VCA 1');
-      expect(constructReadableChannelName('v', 4)).toBe('VCA 4');
+      expect(getDefaultChannelName('v', 1)).toBe('VCA 1');
+      expect(getDefaultChannelName('v', 4)).toBe('VCA 4');
 
-      expect(constructReadableChannelName('l', 1)).toBe('LINE IN L');
-      expect(constructReadableChannelName('l', 2)).toBe('LINE IN R');
-      expect(constructReadableChannelName('p', 1)).toBe('PLAYER L');
-      expect(constructReadableChannelName('p', 2)).toBe('PLAYER R');
+      expect(getDefaultChannelName('l', 1)).toBe('LINE IN L');
+      expect(getDefaultChannelName('l', 2)).toBe('LINE IN R');
+      expect(getDefaultChannelName('p', 1)).toBe('PLAYER L');
+      expect(getDefaultChannelName('p', 2)).toBe('PLAYER R');
+    });
+  });
 
-      expect(constructReadableChannelName('solovol', 1)).toBe('SOLO LEVEL');
-      expect(constructReadableChannelName('hpvol', 1)).toBe('HEADPHONE 1 LEVEL');
-      expect(constructReadableChannelName('hpvol', 2)).toBe('HEADPHONE 2 LEVEL');
+  describe('getDefaultVolumeBusName', () => {
+    it('should construct readable volume bus name', () => {
+      expect(getDefaultVolumeBusName('solovol', 1)).toBe('SOLO LEVEL');
+      expect(getDefaultVolumeBusName('hpvol', 1)).toBe('HEADPHONE 1 LEVEL');
+      expect(getDefaultVolumeBusName('hpvol', 2)).toBe('HEADPHONE 2 LEVEL');
     });
   });
 });

--- a/packages/mixer-connection/src/lib/utils.ts
+++ b/packages/mixer-connection/src/lib/utils.ts
@@ -87,16 +87,12 @@ export function fxTypeToString(type: FxType): keyof typeof FxType {
 }
 
 /**
- * Construct a human-readable name for a channel
+ * Construct the default human-readable name for a channel,
  * based on the default labels from the web interface
- * @param type
- * @param channel
- * @returns
+ * @param type channel type
+ * @param channel channel number
  */
-export function constructReadableChannelName(
-  type: ChannelType | VolumeBusType,
-  channel: number,
-): string {
+export function getDefaultChannelName(type: ChannelType, channel: number): string {
   switch (type) {
     case 'i':
       return 'CH ' + channel;
@@ -112,10 +108,21 @@ export function constructReadableChannelName(
       return 'LINE IN ' + numberToLR(channel);
     case 'p':
       return 'PLAYER ' + numberToLR(channel);
+  }
+}
+
+/**
+ * Construct the default human-readable name for a volume bus (solo or headphones),
+ * based on the default labels from the web interface
+ * @param type volume bus type
+ * @param busId volume bus number
+ */
+export function getDefaultVolumeBusName(type: VolumeBusType, busId: number): string {
+  switch (type) {
     case 'solovol':
       return 'SOLO LEVEL';
     case 'hpvol':
-      return `HEADPHONE ${channel} LEVEL`;
+      return `HEADPHONE ${busId} LEVEL`;
   }
 }
 


### PR DESCRIPTION
## Summary

Pure, behavior-preserving refactor on `main`. Splits `constructReadableChannelName` — which mixed channel and volume-bus naming under a single `ChannelType | VolumeBusType` switch — into two focused helpers:

- `getDefaultChannelName(type: ChannelType, channel)` → channels (`i,l,p,f,s,a,v`)
- `getDefaultVolumeBusName(type: VolumeBusType, busId)` → volume buses (`solovol`, `hpvol`)

`Channel` and `VolumeBus` now call their respective helper. No behavior change.

This sets up a follow-up on `feat/matrix-bus-support` where the `a` (AUX) default name becomes matrix-aware (`MTX n`) via a separate `getDefaultMatrixName` helper — kept out of this PR to keep the refactor clean.

## Tests

- Split the `utils.spec.ts` block into `getDefaultChannelName` and `getDefaultVolumeBusName`.
- `channel.spec.ts`: assert the default `name$` for every channel type (`CH`, `AUX`, `FX`, `SUB`, `VCA`, `LINE IN L/R`, `PLAYER L/R`) when no name is set, and the set-name override for all types.
- `volume-bus.spec.ts`: assert default `name$` (`SOLO LEVEL`, `HEADPHONE n LEVEL`).

All 422 tests pass; lint and `format:check` clean.