### PR TITLE
docs: add browser/CDN quickstart example

### DIFF
--- a/docs/docs/usage/quickstart.md
+++ b/docs/docs/usage/quickstart.md
@@ -45,3 +45,43 @@ node index.mjs
 Open the Soundcraft Web App to see Channel 2 mute and unmute every second.
 
 🎉 **Congratulations! You have successfully set up a new project with our library.**
+
+## Use in the browser (CDN)
+
+To try the library, no separate build process is necessary. You can load the library directly in the browser from a CDN.
+The package is published as CommonJS, so use a CDN that converts it to an ES module (and bundles its RxJS dependency for you):
+
+- **jsDelivr**: append `/+esm`, e.g. `https://cdn.jsdelivr.net/npm/soundcraft-ui-connection/+esm`
+- **unpkg**: append `?module`, e.g. `https://unpkg.com/soundcraft-ui-connection?module`
+
+The following self-contained HTML page connects to a mixer and provides two buttons to mute and unmute an input channel:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Mute channel</title>
+  </head>
+  <body>
+    <button onclick="mute(1)">Mute 1</button>
+    <button onclick="unmute(1)">Unmute 1</button>
+
+    <script type="module">
+      import { SoundcraftUI } from 'https://cdn.jsdelivr.net/npm/soundcraft-ui-connection/+esm';
+
+      const conn = new SoundcraftUI('192.168.1.111');
+      await conn.connect();
+
+      window.mute = function (ch) {
+        conn.master.input(ch).mute();
+      };
+
+      window.unmute = function (ch) {
+        conn.master.input(ch).unmute();
+      };
+    </script>
+  </body>
+</html>
+```
+
+Save this as an `.html` file and open it in your browser. Clicking the buttons mutes and unmutes Channel 1 on the mixer.


### PR DESCRIPTION
## Summary

Adds a "Use in the browser (CDN)" section to the Quick Start docs showing how to use the library directly in a browser without a build step or NPM.

- Explains that the package is CommonJS and needs a CDN that converts it to ESM (bundling the RxJS dependency)
- References two CDNs for ESM conversion: **jsDelivr** (`/+esm`) and **unpkg** (`?module`)
- Includes a self-contained HTML page with two buttons that mute/unmute an input channel

Docs-only change.