### PR TITLE
feat: declare package entry points (main/module/exports)

### DIFF
--- a/docs/docs/usage/quickstart.md
+++ b/docs/docs/usage/quickstart.md
@@ -48,13 +48,13 @@ Open the Soundcraft Web App to see Channel 2 mute and unmute every second.
 
 ## Use in the browser (CDN)
 
-To try the library, no separate build process is necessary. You can load the library directly in the browser from a CDN.
-The package is published as CommonJS, so use a CDN that converts it to an ES module (and bundles its RxJS dependency for you):
+To try the library, no separate build process is necessary. The package ships a self-contained ES module (`index.mjs`) with its RxJS dependency bundled in, so you can load it directly in the browser from any npm CDN, for example [jsDelivr](https://www.jsdelivr.com/) or [unpkg](https://unpkg.com/):
 
-- **jsDelivr**: append `/+esm`, e.g. `https://cdn.jsdelivr.net/npm/soundcraft-ui-connection/+esm`
-- **unpkg**: append `?module`, e.g. `https://unpkg.com/soundcraft-ui-connection?module`
+```javascript
+import { SoundcraftUI } from 'https://cdn.jsdelivr.net/npm/soundcraft-ui-connection/index.mjs';
+```
 
-The following self-contained HTML page connects to a mixer and provides two buttons to mute and unmute an input channel:
+The following HTML page connects to a mixer and provides two buttons to mute and unmute an input channel:
 
 ```html
 <!DOCTYPE html>
@@ -67,7 +67,7 @@ The following self-contained HTML page connects to a mixer and provides two butt
     <button onclick="unmute(1)">Unmute 1</button>
 
     <script type="module">
-      import { SoundcraftUI } from 'https://cdn.jsdelivr.net/npm/soundcraft-ui-connection/+esm';
+      import { SoundcraftUI } from 'https://cdn.jsdelivr.net/npm/soundcraft-ui-connection/index.mjs';
 
       const conn = new SoundcraftUI('192.168.1.111');
       await conn.connect();

--- a/packages/mixer-connection/package.json
+++ b/packages/mixer-connection/package.json
@@ -3,6 +3,17 @@
   "description": "Library for controlling the Soundcraft Ui series audio mixers",
   "version": "6.0.4",
   "type": "commonjs",
+  "main": "./index.js",
+  "module": "./index.mjs",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.mjs",
+      "require": "./index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "license": "MIT",
   "author": "Ferdinand Malcher <ferdinand@malcher.media>",
   "repository": {


### PR DESCRIPTION
## Summary

The published package shipped two builds — `index.js` (CommonJS) and a self-contained `index.mjs` (ESM, with RxJS bundled in) — but its `package.json` declared **no `main`, `module`, or `exports`** fields. As a result, consumers (and CDNs like jsDelivr/unpkg) could not resolve an entry point from a bare package specifier and had to point at the `.mjs` file directly or use conversion endpoints (`/+esm`, `?module`).

This PR adds explicit entry-point metadata so both ESM and CJS consumers resolve the correct build automatically:

```json
"main": "./index.js",
"module": "./index.mjs",
"types": "./index.d.ts",
"exports": {
  ".": { "types": "./index.d.ts", "import": "./index.mjs", "require": "./index.js" },
  "./package.json": "./package.json"
}
```

The browser/CDN section of the Quick Start docs is simplified to a plain ESM import accordingly.

## Verification

- Clean rebuild (`nx build mixer-connection`) emits these fields into `dist/.../package.json`.
- Resolving the package **by name** works for both module systems:
  - ESM `import` → `index.mjs` ✅
  - CJS `require` → `index.js` ✅
- `nx test mixer-connection` passes; `nx format:check` clean.