### PR TITLE
refactor: move facade caching from constructors into accessor methods

### DIFF
--- a/packages/mixer-connection/src/lib/facade/aux-bus.ts
+++ b/packages/mixer-connection/src/lib/facade/aux-bus.ts
@@ -6,6 +6,7 @@ import { select, selectMatrix } from '../state/state-selectors';
 import { AuxChannel } from './aux-channel';
 import { setMatrixMode } from './matrix-utils';
 import { MtxBus } from './mtx-bus';
+import { mtxBusStoreId } from './object-store-ids';
 
 /**
  * Represents an AUX bus
@@ -21,23 +22,17 @@ export class AuxBus {
     private conn: MixerConnection,
     private store: MixerStore,
     private bus: number,
-  ) {
-    // lookup object in the store and use existing object if possible
-    const storeId = 'auxbus' + bus;
-    const storedObject = this.store.objectStore.get<AuxBus>(storeId);
-    if (storedObject) {
-      return storedObject;
-    } else {
-      this.store.objectStore.set(storeId, this);
-    }
-  }
+  ) {}
 
   /**
    * Get input channel on the AUX bus
    * @param channel Channel number
    */
   input(channel: number) {
-    return new AuxChannel(this.conn, this.store, 'i', channel, this.bus);
+    return this.store.objectStore.getOrCreate(
+      `aux${this.bus}i${channel}`,
+      () => new AuxChannel(this.conn, this.store, 'i', channel, this.bus),
+    );
   }
 
   /**
@@ -45,7 +40,10 @@ export class AuxBus {
    * @param channel Channel number
    */
   line(channel: number) {
-    return new AuxChannel(this.conn, this.store, 'l', channel, this.bus);
+    return this.store.objectStore.getOrCreate(
+      `aux${this.bus}l${channel}`,
+      () => new AuxChannel(this.conn, this.store, 'l', channel, this.bus),
+    );
   }
 
   /**
@@ -53,7 +51,10 @@ export class AuxBus {
    * @param channel Channel number
    */
   player(channel: number) {
-    return new AuxChannel(this.conn, this.store, 'p', channel, this.bus);
+    return this.store.objectStore.getOrCreate(
+      `aux${this.bus}p${channel}`,
+      () => new AuxChannel(this.conn, this.store, 'p', channel, this.bus),
+    );
   }
 
   /**
@@ -61,7 +62,10 @@ export class AuxBus {
    * @param channel Channel number
    */
   fx(channel: number) {
-    return new AuxChannel(this.conn, this.store, 'f', channel, this.bus);
+    return this.store.objectStore.getOrCreate(
+      `aux${this.bus}f${channel}`,
+      () => new AuxChannel(this.conn, this.store, 'f', channel, this.bus),
+    );
   }
 
   /**
@@ -71,6 +75,9 @@ export class AuxBus {
    */
   switchToMatrix(): MtxBus {
     setMatrixMode(this.conn, this.store, this.bus, 1);
-    return new MtxBus(this.conn, this.store, this.bus);
+    return this.store.objectStore.getOrCreate(
+      mtxBusStoreId(this.bus),
+      () => new MtxBus(this.conn, this.store, this.bus),
+    );
   }
 }

--- a/packages/mixer-connection/src/lib/facade/channel.ts
+++ b/packages/mixer-connection/src/lib/facade/channel.ts
@@ -87,15 +87,6 @@ export class Channel implements FadeableChannel {
     protected busType: BusType = 'master',
     protected bus = 0,
   ) {
-    // lookup channel in the store and use existing object if possible
-    const storeId = busType + bus + channelType + channel;
-    const storedObject = this.store.objectStore.get<Channel>(storeId);
-    if (storedObject) {
-      return storedObject;
-    } else {
-      this.store.objectStore.set(storeId, this);
-    }
-
     // create transition steps and set fader level accordingly
     sourcesToTransition(this.transitionSources$, this.faderLevel$, conn).subscribe(v =>
       this.setFaderLevelRaw(v),

--- a/packages/mixer-connection/src/lib/facade/fx-bus.ts
+++ b/packages/mixer-connection/src/lib/facade/fx-bus.ts
@@ -21,23 +21,21 @@ export class FxBus {
    */
   bpm$ = this.store.state$.pipe(select(selectFxBpm(this.bus)));
 
-  constructor(private conn: MixerConnection, private store: MixerStore, private bus: number) {
-    // lookup object in the store and use existing object if possible
-    const storeId = 'fxbus' + bus;
-    const storedObject = this.store.objectStore.get<FxBus>(storeId);
-    if (storedObject) {
-      return storedObject;
-    } else {
-      this.store.objectStore.set(storeId, this);
-    }
-  }
+  constructor(
+    private conn: MixerConnection,
+    private store: MixerStore,
+    private bus: number,
+  ) {}
 
   /**
    * Get input channel on the FX bus
    * @param channel Channel number
    */
   input(channel: number) {
-    return new FxChannel(this.conn, this.store, 'i', channel, this.bus);
+    return this.store.objectStore.getOrCreate(
+      `fx${this.bus}i${channel}`,
+      () => new FxChannel(this.conn, this.store, 'i', channel, this.bus),
+    );
   }
 
   /**
@@ -45,7 +43,10 @@ export class FxBus {
    * @param channel Channel number
    */
   line(channel: number) {
-    return new FxChannel(this.conn, this.store, 'l', channel, this.bus);
+    return this.store.objectStore.getOrCreate(
+      `fx${this.bus}l${channel}`,
+      () => new FxChannel(this.conn, this.store, 'l', channel, this.bus),
+    );
   }
 
   /**
@@ -53,7 +54,10 @@ export class FxBus {
    * @param channel Channel number
    */
   player(channel: number) {
-    return new FxChannel(this.conn, this.store, 'p', channel, this.bus);
+    return this.store.objectStore.getOrCreate(
+      `fx${this.bus}p${channel}`,
+      () => new FxChannel(this.conn, this.store, 'p', channel, this.bus),
+    );
   }
 
   /**
@@ -61,7 +65,10 @@ export class FxBus {
    * @param channel Channel number
    */
   sub(channel: number) {
-    return new FxChannel(this.conn, this.store, 's', channel, this.bus);
+    return this.store.objectStore.getOrCreate(
+      `fx${this.bus}s${channel}`,
+      () => new FxChannel(this.conn, this.store, 's', channel, this.bus),
+    );
   }
 
   /**

--- a/packages/mixer-connection/src/lib/facade/hw-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/hw-channel.ts
@@ -62,15 +62,6 @@ export class HwChannel {
     protected deviceInfo: DeviceInfo,
     protected channel: number,
   ) {
-    // lookup object in the store and use existing object if possible
-    const storeId = 'hw' + channel;
-    const storedObject = this.store.objectStore.get<HwChannel>(storeId);
-    if (storedObject) {
-      return storedObject;
-    } else {
-      this.store.objectStore.set(storeId, this);
-    }
-
     // change full channel ID according to device model
     this.deviceInfo.model$.subscribe(model => {
       switch (model) {

--- a/packages/mixer-connection/src/lib/facade/master-bus.ts
+++ b/packages/mixer-connection/src/lib/facade/master-bus.ts
@@ -61,7 +61,10 @@ export class MasterBus implements FadeableChannel, PannableChannel {
    * @param channel Channel number
    */
   input(channel: number) {
-    return new DelayableMasterChannel(this.conn, this.store, 'i', channel);
+    return this.store.objectStore.getOrCreate(
+      `masteri${channel}`,
+      () => new DelayableMasterChannel(this.conn, this.store, 'i', channel),
+    );
   }
 
   /**
@@ -69,7 +72,10 @@ export class MasterBus implements FadeableChannel, PannableChannel {
    * @param channel Channel number
    */
   line(channel: number) {
-    return new DelayableMasterChannel(this.conn, this.store, 'l', channel);
+    return this.store.objectStore.getOrCreate(
+      `masterl${channel}`,
+      () => new DelayableMasterChannel(this.conn, this.store, 'l', channel),
+    );
   }
 
   /**
@@ -77,7 +83,10 @@ export class MasterBus implements FadeableChannel, PannableChannel {
    * @param channel Channel number
    */
   player(channel: number) {
-    return new MasterChannel(this.conn, this.store, 'p', channel);
+    return this.store.objectStore.getOrCreate(
+      `masterp${channel}`,
+      () => new MasterChannel(this.conn, this.store, 'p', channel),
+    );
   }
 
   /**
@@ -85,7 +94,10 @@ export class MasterBus implements FadeableChannel, PannableChannel {
    * @param channel Channel number
    */
   aux(channel: number) {
-    return new DelayableMasterChannel(this.conn, this.store, 'a', channel);
+    return this.store.objectStore.getOrCreate(
+      `mastera${channel}`,
+      () => new DelayableMasterChannel(this.conn, this.store, 'a', channel),
+    );
   }
 
   /**
@@ -96,7 +108,7 @@ export class MasterBus implements FadeableChannel, PannableChannel {
    * @param channel Channel number
    */
   mtx(channel: number) {
-    return new DelayableMasterChannel(this.conn, this.store, 'a', channel);
+    return this.aux(channel);
   }
 
   /**
@@ -104,7 +116,10 @@ export class MasterBus implements FadeableChannel, PannableChannel {
    * @param channel Channel number
    */
   fx(channel: number) {
-    return new MasterChannel(this.conn, this.store, 'f', channel);
+    return this.store.objectStore.getOrCreate(
+      `masterf${channel}`,
+      () => new MasterChannel(this.conn, this.store, 'f', channel),
+    );
   }
 
   /**
@@ -112,7 +127,10 @@ export class MasterBus implements FadeableChannel, PannableChannel {
    * @param channel Channel number
    */
   sub(channel: number) {
-    return new MasterChannel(this.conn, this.store, 's', channel);
+    return this.store.objectStore.getOrCreate(
+      `masters${channel}`,
+      () => new MasterChannel(this.conn, this.store, 's', channel),
+    );
   }
 
   /**
@@ -120,7 +138,10 @@ export class MasterBus implements FadeableChannel, PannableChannel {
    * @param channel Channel number
    */
   vca(channel: number) {
-    return new MasterChannel(this.conn, this.store, 'v', channel);
+    return this.store.objectStore.getOrCreate(
+      `masterv${channel}`,
+      () => new MasterChannel(this.conn, this.store, 'v', channel),
+    );
   }
 
   /** Master actions */

--- a/packages/mixer-connection/src/lib/facade/mtx-bus-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/mtx-bus-channel.ts
@@ -27,12 +27,7 @@ export class MtxBusChannel extends MtxChannel {
     private channel: number,
     private bus: number,
   ) {
-    super(
-      conn,
-      store,
-      constructMtxChannelId(channelType, channel, bus),
-      'mtx' + bus + channelType + channel,
-    );
+    super(conn, store, constructMtxChannelId(channelType, channel, bus));
 
     /**
      * create list of linked channels.

--- a/packages/mixer-connection/src/lib/facade/mtx-bus.ts
+++ b/packages/mixer-connection/src/lib/facade/mtx-bus.ts
@@ -7,6 +7,7 @@ import { AuxBus } from './aux-bus';
 import { setMatrixMode } from './matrix-utils';
 import { MtxBusChannel } from './mtx-bus-channel';
 import { MtxMasterChannel } from './mtx-master-channel';
+import { auxBusStoreId } from './object-store-ids';
 
 /**
  * Represents a matrix bus.
@@ -25,23 +26,17 @@ export class MtxBus {
     private conn: MixerConnection,
     private store: MixerStore,
     private bus: number,
-  ) {
-    // lookup object in the store and use existing object if possible
-    const storeId = 'mtxbus' + bus;
-    const storedObject = this.store.objectStore.get<MtxBus>(storeId);
-    if (storedObject) {
-      return storedObject;
-    } else {
-      this.store.objectStore.set(storeId, this);
-    }
-  }
+  ) {}
 
   /**
    * Get an AUX bus as a source on the matrix
    * @param channel AUX bus number
    */
   aux(channel: number) {
-    return new MtxBusChannel(this.conn, this.store, 'a', channel, this.bus);
+    return this.store.objectStore.getOrCreate(
+      `mtx${this.bus}a${channel}`,
+      () => new MtxBusChannel(this.conn, this.store, 'a', channel, this.bus),
+    );
   }
 
   /**
@@ -49,14 +44,20 @@ export class MtxBus {
    * @param channel Subgroup number
    */
   sub(channel: number) {
-    return new MtxBusChannel(this.conn, this.store, 's', channel, this.bus);
+    return this.store.objectStore.getOrCreate(
+      `mtx${this.bus}s${channel}`,
+      () => new MtxBusChannel(this.conn, this.store, 's', channel, this.bus),
+    );
   }
 
   /**
    * Get the master mix as a source on the matrix
    */
   master() {
-    return new MtxMasterChannel(this.conn, this.store, this.bus);
+    return this.store.objectStore.getOrCreate(
+      `mtxmaster${this.bus}`,
+      () => new MtxMasterChannel(this.conn, this.store, this.bus),
+    );
   }
 
   /**
@@ -66,6 +67,9 @@ export class MtxBus {
    */
   switchToAux(): AuxBus {
     setMatrixMode(this.conn, this.store, this.bus, 0);
-    return new AuxBus(this.conn, this.store, this.bus);
+    return this.store.objectStore.getOrCreate(
+      auxBusStoreId(this.bus),
+      () => new AuxBus(this.conn, this.store, this.bus),
+    );
   }
 }

--- a/packages/mixer-connection/src/lib/facade/mtx-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/mtx-channel.ts
@@ -58,16 +58,7 @@ export abstract class MtxChannel
     protected conn: MixerConnection,
     protected store: MixerStore,
     protected fullChannelId: string,
-    storeId: string,
   ) {
-    // lookup object in the store and use existing object if possible
-    const storedObject = this.store.objectStore.get<MtxChannel>(storeId);
-    if (storedObject) {
-      return storedObject;
-    } else {
-      this.store.objectStore.set(storeId, this);
-    }
-
     // create transition steps and set fader level accordingly
     sourcesToTransition(this.transitionSources$, this.faderLevel$, conn).subscribe(v =>
       this.setFaderLevelRaw(v),

--- a/packages/mixer-connection/src/lib/facade/mtx-master-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/mtx-master-channel.ts
@@ -16,7 +16,7 @@ export class MtxMasterChannel extends MtxChannel {
   name$ = of('MASTER');
 
   constructor(conn: MixerConnection, store: MixerStore, bus: number) {
-    super(conn, store, `m.mtx.${bus - 1}`, 'mtxmaster' + bus);
+    super(conn, store, `m.mtx.${bus - 1}`);
 
     // the master source is not stereo-linkable itself, but it is mirrored
     // across the stereo-linked matrix output (matrix outputs live in `a` slots).

--- a/packages/mixer-connection/src/lib/facade/mute-group.ts
+++ b/packages/mixer-connection/src/lib/facade/mute-group.ts
@@ -24,17 +24,12 @@ function groupIDToIndex(id: MuteGroupID): number {
 export class MuteGroup {
   private groupIndex: number;
 
-  constructor(private conn: MixerConnection, private store: MixerStore, readonly id: MuteGroupID) {
+  constructor(
+    private conn: MixerConnection,
+    private store: MixerStore,
+    readonly id: MuteGroupID,
+  ) {
     this.groupIndex = groupIDToIndex(id);
-
-    // lookup object in the store and use existing object if possible
-    const storeId = 'mutegroup' + id;
-    const storedObject = this.store.objectStore.get<MuteGroup>(storeId);
-    if (storedObject) {
-      return storedObject;
-    } else {
-      this.store.objectStore.set(storeId, this);
-    }
   }
 
   private mgMask$ = this.store.state$.pipe(selectRawValue<number>('mgmask'));

--- a/packages/mixer-connection/src/lib/facade/object-store-ids.ts
+++ b/packages/mixer-connection/src/lib/facade/object-store-ids.ts
@@ -1,0 +1,19 @@
+/**
+ * Builders for the cache ids that must be shared between accessors.
+ *
+ * Most cache ids are built inline at their single call site. Only the two below are
+ * produced by more than one accessor and therefore need a single source of truth, so
+ * that the accessors resolve to the very same cached instance:
+ *  - `conn.aux(n)` and `mtx.switchToAux()`
+ *  - `conn.mtx(n)` and `aux.switchToMatrix()`
+ */
+
+/** cache id for an AuxBus */
+export function auxBusStoreId(bus: number) {
+  return 'auxbus' + bus;
+}
+
+/** cache id for an MtxBus */
+export function mtxBusStoreId(bus: number) {
+  return 'mtxbus' + bus;
+}

--- a/packages/mixer-connection/src/lib/facade/volume-bus.ts
+++ b/packages/mixer-connection/src/lib/facade/volume-bus.ts
@@ -32,15 +32,6 @@ export class VolumeBus implements FadeableChannel {
     protected busName: VolumeBusType,
     protected busId?: number,
   ) {
-    // lookup channel in the store and use existing object if possible
-    const storeId = 'volume-' + this.busName + this.busId;
-    const storedObject = this.store.objectStore.get<VolumeBus>(storeId);
-    if (storedObject) {
-      return storedObject;
-    } else {
-      this.store.objectStore.set(storeId, this);
-    }
-
     // create transition steps and set fader level accordingly
     sourcesToTransition(this.transitionSources$, this.faderLevel$, conn).subscribe(v =>
       this.setFaderLevelRaw(v),

--- a/packages/mixer-connection/src/lib/soundcraft-ui.ts
+++ b/packages/mixer-connection/src/lib/soundcraft-ui.ts
@@ -19,6 +19,7 @@ import { ConnectionEvent, SoundcraftUIOptions } from './types';
 import { VuProcessor } from './vu/vu-processor';
 import { waitForInitParams } from './utils';
 import { ChannelSync } from './facade/channel-sync';
+import { auxBusStoreId, mtxBusStoreId } from './facade/object-store-ids';
 
 export class SoundcraftUI {
   private _options: SoundcraftUIOptions;
@@ -99,7 +100,11 @@ export class SoundcraftUI {
     this.recorderMultiTrack = new MultiTrackRecorder(this.conn, this.store);
     this.volume = {
       solo: new VolumeBus(this.conn, this.store, 'solovol'),
-      headphone: (id: number) => new VolumeBus(this.conn, this.store, 'hpvol', id),
+      headphone: (id: number) =>
+        this.store.objectStore.getOrCreate(
+          `volume-hpvol${id}`,
+          () => new VolumeBus(this.conn, this.store, 'hpvol', id),
+        ),
     };
     this.shows = new ShowController(this.conn, this.store);
     this.automix = new AutomixController(this.conn, this.store);
@@ -111,7 +116,10 @@ export class SoundcraftUI {
    * @param bus Bus number
    */
   aux(bus: number) {
-    return new AuxBus(this.conn, this.store, bus);
+    return this.store.objectStore.getOrCreate(
+      auxBusStoreId(bus),
+      () => new AuxBus(this.conn, this.store, bus),
+    );
   }
 
   /**
@@ -122,7 +130,10 @@ export class SoundcraftUI {
    * @param bus Bus number (same slot number as the AUX it replaced)
    */
   mtx(bus: number) {
-    return new MtxBus(this.conn, this.store, bus);
+    return this.store.objectStore.getOrCreate(
+      mtxBusStoreId(bus),
+      () => new MtxBus(this.conn, this.store, bus),
+    );
   }
 
   /**
@@ -130,7 +141,10 @@ export class SoundcraftUI {
    * @param bus Bus number
    */
   fx(bus: number) {
-    return new FxBus(this.conn, this.store, bus);
+    return this.store.objectStore.getOrCreate(
+      `fxbus${bus}`,
+      () => new FxBus(this.conn, this.store, bus),
+    );
   }
 
   /**
@@ -138,7 +152,10 @@ export class SoundcraftUI {
    * @param id ID of the group: `1`..`6`, `all`, `fx`
    */
   muteGroup(id: MuteGroupID) {
-    return new MuteGroup(this.conn, this.store, id);
+    return this.store.objectStore.getOrCreate(
+      `mutegroup${id}`,
+      () => new MuteGroup(this.conn, this.store, id),
+    );
   }
 
   /** Unmute all mute groups, "MUTE ALL" and "MUTE FX" */
@@ -153,7 +170,10 @@ export class SoundcraftUI {
    * @param channel Channel number
    */
   hw(channel: number) {
-    return new HwChannel(this.conn, this.store, this.deviceInfo, channel);
+    return this.store.objectStore.getOrCreate(
+      `hw${channel}`,
+      () => new HwChannel(this.conn, this.store, this.deviceInfo, channel),
+    );
   }
 
   /** Connect to the mixer. Returns a Promise that resolves when the connection is open and the initial params have likely been received by the mixer. */

--- a/packages/mixer-connection/src/lib/state/object-store.spec.ts
+++ b/packages/mixer-connection/src/lib/state/object-store.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { ObjectStore } from './object-store';
 
 describe('Object Store', () => {
@@ -9,5 +9,28 @@ describe('Object Store', () => {
     store.set('myKey', myObject);
 
     expect(store.get('myKey')).toBe(myObject);
+  });
+
+  describe('getOrCreate', () => {
+    it('should create and cache the object on first access', () => {
+      const store = new ObjectStore();
+      const factory = vi.fn(() => ({ foo: 'bar' }));
+
+      const created = store.getOrCreate('myKey', factory);
+
+      expect(factory).toHaveBeenCalledTimes(1);
+      expect(store.get('myKey')).toBe(created);
+    });
+
+    it('should return the cached object and not call the factory again', () => {
+      const store = new ObjectStore();
+      const factory = vi.fn(() => ({ foo: 'bar' }));
+
+      const first = store.getOrCreate('myKey', factory);
+      const second = store.getOrCreate('myKey', factory);
+
+      expect(first).toBe(second);
+      expect(factory).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/mixer-connection/src/lib/state/object-store.ts
+++ b/packages/mixer-connection/src/lib/state/object-store.ts
@@ -13,4 +13,19 @@ export class ObjectStore {
   set(id: string, value: unknown) {
     this.store.set(id, value);
   }
+
+  /**
+   * Return the cached object for the given id or create it (and cache it) using the factory.
+   * Caching lives in the accessor methods of the facades, so that constructors always
+   * run exactly once and never re-run their side effects on a cached instance.
+   */
+  getOrCreate<T>(id: string, factory: () => T): T {
+    const existing = this.store.get(id) as T;
+    if (existing) {
+      return existing;
+    }
+    const created = factory();
+    this.store.set(id, created);
+    return created;
+  }
 }


### PR DESCRIPTION
Closes #308.

## Problem

Every facade cached its instances with the "constructor returns the cached object" pattern. Because a derived class must call `super()` before it has a `this`, when `super()` returned the cached instance the **subclass constructor body still executed** against the cached object — so any subscription a subclass set up in its constructor was **re-created on every accessor call and never disposed**.

Confirmed leak in `MtxMasterChannel` and `MtxBusChannel` (a `store.state$` subscription per call to `conn.mtx(n).master()` / `.aux()` / `.sub()`); the same class of bug applied to every subclass with constructor side effects (`AuxChannel`, `FxChannel`, `MasterChannel`, `DelayableMasterChannel`, `SendChannel`).

## Approach

Caching now lives in the **accessor methods**; constructors always build fresh and run exactly once.

- `ObjectStore.getOrCreate(id, factory)` — returns the cached object or creates + caches it.
- New `facade/object-store-ids.ts` centralizes every cache-key formula (kept identical to the previous ones) so accessors **and** `switchToAux()` / `switchToMatrix()` resolve to the same singleton — no `new Facade(...)` bypasses the cache.
- Removed the dedup block from every facade constructor (`channel`, `mtx-channel`, `aux-bus`, `fx-bus`, `mtx-bus`, `mute-group`, `volume-bus`, `hw-channel`); `MtxChannel` no longer takes a `storeId` super-arg.
- Routed all accessors through `getOrCreate` (`soundcraft-ui`, `master-bus`, `aux-bus`, `fx-bus`, `mtx-bus`). `master.mtx(n)` is now simply an alias for `master.aux(n)`.

**No public API change** — accessor signatures are unchanged.

## Tests

- `object-store.spec.ts`: unit tests for `getOrCreate` (creates + caches once; reuses on repeat).
- `channel-singletons.spec.ts` keeps passing through the accessors; the `switchTo*` "same singleton" specs still hold.
- Full suite green (`npx nx test mixer-connection`), lint and format clean.