### PR TITLE
SETD/SETS value handling: correct conversion + setd()/sets() helpers

### DIFF
--- a/docs/docs/more/raw.md
+++ b/docs/docs/more/raw.md
@@ -17,6 +17,17 @@ conn.conn.sendMessage('SETD^m.mix^0.4');
 conn.conn.sendMessage('SETD^i.2.mute^0');
 ```
 
+For the two most common commands there are typed helpers that build the message string for you. They make the distinction between numeric and string values explicit:
+
+- `conn.conn.setd(path, value)`: send a `SETD` command. `SETD` messages carry **numeric** values, e.g. fader levels, mute states or gains.
+- `conn.conn.sets(path, value)`: send a `SETS` command. `SETS` messages carry **string** values, e.g. channel names.
+
+```ts
+conn.conn.setd('m.mix', 0.4);
+conn.conn.setd('i.2.mute', 0);
+conn.conn.sets('i.2.name', 'Vocals');
+```
+
 :::warning
 
 **Please prefer the human-readable interface over using the raw format!** If you're missing any features, please [file an issue](https://github.com/fmalcher/soundcraft-ui/issues) or [Pull Request](https://github.com/fmalcher/soundcraft-ui/pulls).

--- a/packages/mixer-connection/src/lib/facade/automix-controller.ts
+++ b/packages/mixer-connection/src/lib/facade/automix-controller.ts
@@ -13,11 +13,11 @@ export class AutomixGroup {
   constructor(
     private conn: MixerConnection,
     private store: MixerStore,
-    private group: AutomixGroupId
+    private group: AutomixGroupId,
   ) {}
 
   private setState(value: number) {
-    this.conn.sendMessage(`SETD^automix.${this.group}.on^${value}`);
+    this.conn.setd(`automix.${this.group}.on`, value);
   }
 
   /** Enable this automix group */
@@ -51,7 +51,7 @@ export class AutomixController {
    * @param value linear value between `0` and `1`
    */
   setResponseTime(value: number) {
-    this.conn.sendMessage(`SETD^automix.time^${value}`);
+    this.conn.setd('automix.time', value);
   }
 
   /**
@@ -68,5 +68,8 @@ export class AutomixController {
     b: new AutomixGroup(this.conn, this.store, 'b'),
   };
 
-  constructor(private conn: MixerConnection, private store: MixerStore) {}
+  constructor(
+    private conn: MixerConnection,
+    private store: MixerStore,
+  ) {}
 }

--- a/packages/mixer-connection/src/lib/facade/aux-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/aux-channel.ts
@@ -85,8 +85,7 @@ export class AuxChannel extends SendChannel implements PannableChannel, PostProc
     value = clamp(value, 0, 1);
     value = roundToThreeDecimals(value);
     [...this.auxLinkChannelIds, this.fullChannelId].forEach(cid => {
-      const command = `SETD^${cid}.pan^${value}`;
-      this.conn.sendMessage(command);
+      this.conn.setd(`${cid}.pan`, value);
     });
   }
 
@@ -105,8 +104,7 @@ export class AuxChannel extends SendChannel implements PannableChannel, PostProc
    */
   setPostProc(value: number) {
     [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
-      const command = `SETD^${cid}.postproc^${value}`;
-      this.conn.sendMessage(command);
+      this.conn.setd(`${cid}.postproc`, value);
     });
   }
 

--- a/packages/mixer-connection/src/lib/facade/channel.ts
+++ b/packages/mixer-connection/src/lib/facade/channel.ts
@@ -134,8 +134,7 @@ export class Channel implements FadeableChannel {
 
   private setFaderLevelRaw(value: number) {
     [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
-      const command = `SETD^${cid}.${this.faderLevelCommand}^${value}`;
-      this.conn.sendMessage(command);
+      this.conn.setd(`${cid}.${this.faderLevelCommand}`, value);
     });
   }
 
@@ -173,8 +172,7 @@ export class Channel implements FadeableChannel {
    */
   setMute(value: number) {
     [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
-      const command = `SETD^${cid}.mute^${value}`;
-      this.conn.sendMessage(command);
+      this.conn.setd(`${cid}.mute`, value);
     });
   }
 
@@ -197,6 +195,6 @@ export class Channel implements FadeableChannel {
   setName(name: string) {
     name = sanitizeChannelName(name);
     const path = joinStatePath(this.channelType, this.channel - 1, 'name');
-    this.conn.sendMessage(`SETS^${path}^${name}`);
+    this.conn.sets(path, name);
   }
 }

--- a/packages/mixer-connection/src/lib/facade/delayable-master-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/delayable-master-channel.ts
@@ -34,8 +34,7 @@ export class DelayableMasterChannel extends MasterChannel {
   setDelay(ms: number) {
     const value = sanitizeDelayValue(ms, this.delayMaxValueMs);
 
-    const command = `SETD^${this.fullChannelId}.delay^${value}`;
-    this.conn.sendMessage(command);
+    this.conn.setd(`${this.fullChannelId}.delay`, value);
   }
 
   /**

--- a/packages/mixer-connection/src/lib/facade/device-info.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/device-info.spec.ts
@@ -54,10 +54,10 @@ describe('DeviceInfo', () => {
   });
 
   it('firmware$', async () => {
-    conn.conn.sendMessage('SETD^firmware^1.2.3');
+    conn.conn.sendMessage('SETS^firmware^1.2.3');
     expect(await firstValueFrom(conn.deviceInfo.firmware$)).toBe('1.2.3');
 
-    conn.conn.sendMessage('SETD^firmware^4.5.6-abc');
+    conn.conn.sendMessage('SETS^firmware^4.5.6-abc');
     expect(await firstValueFrom(conn.deviceInfo.firmware$)).toBe('4.5.6-abc');
   });
 });

--- a/packages/mixer-connection/src/lib/facade/fx-bus.ts
+++ b/packages/mixer-connection/src/lib/facade/fx-bus.ts
@@ -79,7 +79,7 @@ export class FxBus {
     value = clamp(value, 20, 400);
     value = Math.round(value); // make integer
 
-    this.conn.sendMessage(`SETD^f.${this.bus - 1}.bpm^${value}`);
+    this.conn.setd(`f.${this.bus - 1}.bpm`, value);
   }
 
   private assertFxParamInRange(param: number) {
@@ -112,6 +112,6 @@ export class FxBus {
     this.assertFxParamInRange(param);
 
     value = clamp(value, 0, 1);
-    this.conn.sendMessage(`SETD^${this.makeFxParamPath(param)}^${value}`);
+    this.conn.setd(this.makeFxParamPath(param), value);
   }
 }

--- a/packages/mixer-connection/src/lib/facade/hw-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/hw-channel.ts
@@ -81,8 +81,7 @@ export class HwChannel {
    * @param value `0` or `1`
    */
   setPhantom(value: number) {
-    const command = `SETD^${this.fullChannelId}.phantom^${value}`;
-    this.conn.sendMessage(command);
+    this.conn.setd(`${this.fullChannelId}.phantom`, value);
   }
 
   /** Switch ON phantom power for the channel */
@@ -106,8 +105,7 @@ export class HwChannel {
    */
   setGain(value: number) {
     value = clamp(value, 0, 1);
-    const command = `SETD^${this.fullChannelId}.gain^${value}`;
-    this.conn.sendMessage(command);
+    this.conn.setd(`${this.fullChannelId}.gain`, value);
   }
 
   /**

--- a/packages/mixer-connection/src/lib/facade/master-bus.ts
+++ b/packages/mixer-connection/src/lib/facade/master-bus.ts
@@ -186,8 +186,7 @@ export class MasterBus implements FadeableChannel, PannableChannel {
   }
 
   private setFaderLevelRaw(value: number) {
-    const command = `SETD^m.mix^${value}`;
-    this.conn.sendMessage(command);
+    this.conn.setd('m.mix', value);
   }
 
   /**
@@ -225,8 +224,7 @@ export class MasterBus implements FadeableChannel, PannableChannel {
   setPan(value: number) {
     value = clamp(value, 0, 1);
     value = roundToThreeDecimals(value);
-    const command = `SETD^m.pan^${value}`;
-    this.conn.sendMessage(command);
+    this.conn.setd('m.pan', value);
   }
 
   /**
@@ -242,8 +240,7 @@ export class MasterBus implements FadeableChannel, PannableChannel {
    * @param value DIM value `0` or `1`
    */
   setDim(value: number) {
-    const command = `SETD^m.dim^${value}`;
-    this.conn.sendMessage(command);
+    this.conn.setd('m.dim', value);
   }
 
   /** Enable DIM on the master */
@@ -289,6 +286,6 @@ export class MasterBus implements FadeableChannel, PannableChannel {
 
   private setDelay(ms: number, side: 'L' | 'R') {
     const value = sanitizeDelayValue(ms, 500);
-    this.conn.sendMessage(`SETD^m.delay${side}^${value}`);
+    this.conn.setd(`m.delay${side}`, value);
   }
 }

--- a/packages/mixer-connection/src/lib/facade/master-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/master-channel.ts
@@ -80,8 +80,7 @@ export class MasterChannel extends Channel implements PannableChannel {
   setPan(value: number) {
     value = clamp(value, 0, 1);
     value = roundToThreeDecimals(value);
-    const command = `SETD^${this.fullChannelId}.pan^${value}`;
-    this.conn.sendMessage(command);
+    this.conn.setd(`${this.fullChannelId}.pan`, value);
   }
 
   /**
@@ -98,8 +97,7 @@ export class MasterChannel extends Channel implements PannableChannel {
    */
   setSolo(value: number) {
     [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
-      const command = `SETD^${cid}.solo^${value}`;
-      this.conn.sendMessage(command);
+      this.conn.setd(`${cid}.solo`, value);
     });
   }
 
@@ -127,8 +125,7 @@ export class MasterChannel extends Channel implements PannableChannel {
   private multiTrackSetSelection(value: number) {
     this.multiTrackAssertChannelType();
 
-    const command = `SETD^${this.fullChannelId}.mtkrec^${value}`;
-    this.conn.sendMessage(command);
+    this.conn.setd(`${this.fullChannelId}.mtkrec`, value);
   }
 
   /** Select this channel for multitrack recording */
@@ -171,8 +168,7 @@ export class MasterChannel extends Channel implements PannableChannel {
     }
 
     [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
-      const command = `SETD^${cid}.amixgroup^${groupValue}`;
-      this.conn.sendMessage(command);
+      this.conn.setd(`${cid}.amixgroup`, groupValue);
     });
   }
 
@@ -189,8 +185,7 @@ export class MasterChannel extends Channel implements PannableChannel {
     value = clamp(value, 0, 1);
 
     [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
-      const command = `SETD^${cid}.amix^${value}`;
-      this.conn.sendMessage(command);
+      this.conn.setd(`${cid}.amix`, value);
     });
   }
 

--- a/packages/mixer-connection/src/lib/facade/matrix-utils.ts
+++ b/packages/mixer-connection/src/lib/facade/matrix-utils.ts
@@ -21,13 +21,13 @@ export function setMatrixMode(
   value: number,
 ) {
   // always switch the slot itself
-  conn.sendMessage(`SETD^a.${bus - 1}.matrix^${value}`);
+  conn.setd(`a.${bus - 1}.matrix`, value);
 
   // also switch the stereo-linked neighbour, if the slot is currently linked
   store.state$.pipe(select(selectStereoIndex('a', bus)), take(1)).subscribe(stereoIndex => {
     const linkedBus = getLinkedChannelNumber(bus, stereoIndex);
     if (linkedBus !== undefined) {
-      conn.sendMessage(`SETD^a.${linkedBus - 1}.matrix^${value}`);
+      conn.setd(`a.${linkedBus - 1}.matrix`, value);
     }
   });
 }

--- a/packages/mixer-connection/src/lib/facade/mtx-bus-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/mtx-bus-channel.ts
@@ -75,6 +75,6 @@ export class MtxBusChannel extends MtxChannel {
   setName(name: string) {
     name = sanitizeChannelName(name);
     const path = joinStatePath(this.channelType, this.channel - 1, 'name');
-    this.conn.sendMessage(`SETS^${path}^${name}`);
+    this.conn.sets(path, name);
   }
 }

--- a/packages/mixer-connection/src/lib/facade/mtx-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/mtx-channel.ts
@@ -101,8 +101,7 @@ export abstract class MtxChannel
 
   private setFaderLevelRaw(value: number) {
     [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
-      const command = `SETD^${cid}.value^${value}`;
-      this.conn.sendMessage(command);
+      this.conn.setd(`${cid}.value`, value);
     });
   }
 
@@ -140,8 +139,7 @@ export abstract class MtxChannel
    */
   setMute(value: number) {
     [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
-      const command = `SETD^${cid}.mute^${value}`;
-      this.conn.sendMessage(command);
+      this.conn.setd(`${cid}.mute`, value);
     });
   }
 
@@ -169,8 +167,7 @@ export abstract class MtxChannel
     value = clamp(value, 0, 1);
     value = roundToThreeDecimals(value);
     [...this.panLinkChannelIds, this.fullChannelId].forEach(cid => {
-      const command = `SETD^${cid}.pan^${value}`;
-      this.conn.sendMessage(command);
+      this.conn.setd(`${cid}.pan`, value);
     });
   }
 
@@ -189,8 +186,7 @@ export abstract class MtxChannel
    */
   setPostProc(value: number) {
     [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
-      const command = `SETD^${cid}.postproc^${value}`;
-      this.conn.sendMessage(command);
+      this.conn.setd(`${cid}.postproc`, value);
     });
   }
 

--- a/packages/mixer-connection/src/lib/facade/multi-track-recorder.ts
+++ b/packages/mixer-connection/src/lib/facade/multi-track-recorder.ts
@@ -16,7 +16,7 @@ import { MtkState } from '../types';
 export class MultiTrackRecorder {
   /** Current state (playing, stopped, paused) */
   state$ = this.store.state$.pipe(
-    selectRawValue<MtkState>('var.mtk.currentState', MtkState.Stopped)
+    selectRawValue<MtkState>('var.mtk.currentState', MtkState.Stopped),
   );
 
   /** Current session name (e.g. `0001` or individual name) */
@@ -29,7 +29,7 @@ export class MultiTrackRecorder {
       } else {
         return value;
       }
-    })
+    }),
   );
 
   /** Current session length in seconds */
@@ -51,13 +51,16 @@ export class MultiTrackRecorder {
   recordingTime$ = this.store.state$.pipe(
     selectRawValue('var.mtk.rec.time', 0),
     withLatestFrom(this.recording$),
-    map(([value, recording]) => (recording ? value : 0)) // set to 0 if not actually recording. otherwise, it emits strange values
+    map(([value, recording]) => (recording ? value : 0)), // set to 0 if not actually recording. otherwise, it emits strange values
   );
 
   /** Soundcheck activation state (`0` or `1`) */
   soundcheck$ = this.store.state$.pipe(selectRawValue('var.mtk.soundcheck', 0));
 
-  constructor(private conn: MixerConnection, private store: MixerStore) {}
+  constructor(
+    private conn: MixerConnection,
+    private store: MixerStore,
+  ) {}
 
   /** Start the player */
   play() {
@@ -104,8 +107,7 @@ export class MultiTrackRecorder {
    * @param value `0` or `1`
    */
   setSoundcheck(value: number) {
-    const command = `SETD^var.mtk.soundcheck^${value}`;
-    this.conn.sendMessage(command);
+    this.conn.setd('var.mtk.soundcheck', value);
   }
 
   /** Activate soundcheck */

--- a/packages/mixer-connection/src/lib/facade/mute-group.ts
+++ b/packages/mixer-connection/src/lib/facade/mute-group.ts
@@ -53,7 +53,6 @@ export class MuteGroup {
   }
 
   private setMgMask(mask: number) {
-    const command = `SETD^mgmask^${mask}`;
-    this.conn.sendMessage(command);
+    this.conn.setd('mgmask', mask);
   }
 }

--- a/packages/mixer-connection/src/lib/facade/player.ts
+++ b/packages/mixer-connection/src/lib/facade/player.ts
@@ -17,7 +17,7 @@ import { PlayerState } from '../types';
 export class Player {
   /** Current state (playing, stopped, paused) */
   state$ = this.store.state$.pipe(
-    selectRawValue<PlayerState>('var.currentState', PlayerState.Stopped)
+    selectRawValue<PlayerState>('var.currentState', PlayerState.Stopped),
   );
 
   /** Current playlist name */
@@ -38,7 +38,10 @@ export class Player {
   /** Shuffle setting (`0` or `1`) */
   shuffle$ = this.store.state$.pipe(selectRawValue('settings.shuffle', 0));
 
-  constructor(private conn: MixerConnection, private store: MixerStore) {}
+  constructor(
+    private conn: MixerConnection,
+    private store: MixerStore,
+  ) {}
 
   /** Start the media player */
   play() {
@@ -87,7 +90,7 @@ export class Player {
    * @param value `0` or `1`
    */
   setShuffle(value: number) {
-    this.conn.sendMessage(`SETD^settings.shuffle^${value}`);
+    this.conn.setd('settings.shuffle', value);
   }
 
   /**
@@ -103,7 +106,7 @@ export class Player {
    * @param value
    */
   setPlayMode(value: number) {
-    this.conn.sendMessage(`SETD^settings.playMode^${value}`);
+    this.conn.setd('settings.playMode', value);
   }
 
   /** Enable manual mode */

--- a/packages/mixer-connection/src/lib/facade/send-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/send-channel.ts
@@ -42,8 +42,7 @@ export class SendChannel extends Channel {
    */
   setPost(value: number) {
     [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
-      const command = `SETD^${cid}.post^${value}`;
-      this.conn.sendMessage(command);
+      this.conn.setd(`${cid}.post`, value);
     });
   }
 

--- a/packages/mixer-connection/src/lib/facade/show-controller.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/show-controller.spec.ts
@@ -10,25 +10,25 @@ describe('Show Controller', () => {
   });
 
   it('currentShow$', async () => {
-    conn.conn.sendMessage('SETD^var.currentShow^THESHOW');
+    conn.conn.sendMessage('SETS^var.currentShow^THESHOW');
     expect(await firstValueFrom(conn.shows.currentShow$)).toBe('THESHOW');
   });
 
   it('currentSnapshot$', async () => {
-    conn.conn.sendMessage('SETD^var.currentSnapshot^THESNAPSHOT');
+    conn.conn.sendMessage('SETS^var.currentSnapshot^THESNAPSHOT');
     expect(await firstValueFrom(conn.shows.currentSnapshot$)).toBe('THESNAPSHOT');
   });
 
   it('currentCue$', async () => {
-    conn.conn.sendMessage('SETD^var.currentCue^THECUE');
+    conn.conn.sendMessage('SETS^var.currentCue^THECUE');
     expect(await firstValueFrom(conn.shows.currentCue$)).toBe('THECUE');
   });
 
   describe('updateCurrentSnapshot', () => {
     it('should send SAVESNAPSHOT message', () => {
-      conn.conn.sendMessage('SETD^var.currentShow^THESHOW');
-      conn.conn.sendMessage('SETD^var.currentSnapshot^THESNAPSHOT');
-      conn.conn.sendMessage('SETD^var.currentCue^THECUE');
+      conn.conn.sendMessage('SETS^var.currentShow^THESHOW');
+      conn.conn.sendMessage('SETS^var.currentSnapshot^THESNAPSHOT');
+      conn.conn.sendMessage('SETS^var.currentCue^THECUE');
 
       conn.conn.sendMessage = vi.fn();
       conn.shows.updateCurrentSnapshot();
@@ -37,8 +37,8 @@ describe('Show Controller', () => {
     });
 
     it('should not send message when no snapshot is given', () => {
-      conn.conn.sendMessage('SETD^var.currentShow^THESHOW');
-      conn.conn.sendMessage('SETD^var.currentCue^THECUE');
+      conn.conn.sendMessage('SETS^var.currentShow^THESHOW');
+      conn.conn.sendMessage('SETS^var.currentCue^THECUE');
 
       conn.conn.sendMessage = vi.fn();
       conn.shows.updateCurrentSnapshot();
@@ -47,8 +47,8 @@ describe('Show Controller', () => {
     });
 
     it('should not send message when no show is given', () => {
-      conn.conn.sendMessage('SETD^var.currentSnapshot^THESNAPSHOT');
-      conn.conn.sendMessage('SETD^var.currentCue^THECUE');
+      conn.conn.sendMessage('SETS^var.currentSnapshot^THESNAPSHOT');
+      conn.conn.sendMessage('SETS^var.currentCue^THECUE');
 
       conn.conn.sendMessage = vi.fn();
       conn.shows.updateCurrentSnapshot();
@@ -59,9 +59,9 @@ describe('Show Controller', () => {
 
   describe('updateCurrentCue', () => {
     it('should send SAVECUE message', () => {
-      conn.conn.sendMessage('SETD^var.currentShow^THESHOW');
-      conn.conn.sendMessage('SETD^var.currentSnapshot^THESNAPSHOT');
-      conn.conn.sendMessage('SETD^var.currentCue^THECUE');
+      conn.conn.sendMessage('SETS^var.currentShow^THESHOW');
+      conn.conn.sendMessage('SETS^var.currentSnapshot^THESNAPSHOT');
+      conn.conn.sendMessage('SETS^var.currentCue^THECUE');
 
       conn.conn.sendMessage = vi.fn();
       conn.shows.updateCurrentCue();
@@ -70,8 +70,8 @@ describe('Show Controller', () => {
     });
 
     it('should not send message when no cue is given', () => {
-      conn.conn.sendMessage('SETD^var.currentShow^THESHOW');
-      conn.conn.sendMessage('SETD^var.currentSnapshot^THESNAPSHOT');
+      conn.conn.sendMessage('SETS^var.currentShow^THESHOW');
+      conn.conn.sendMessage('SETS^var.currentSnapshot^THESNAPSHOT');
 
       conn.conn.sendMessage = vi.fn();
       conn.shows.updateCurrentCue();
@@ -80,8 +80,8 @@ describe('Show Controller', () => {
     });
 
     it('should not send message when no show is given', () => {
-      conn.conn.sendMessage('SETD^var.currentSnapshot^THESNAPSHOT');
-      conn.conn.sendMessage('SETD^var.currentCue^THECUE');
+      conn.conn.sendMessage('SETS^var.currentSnapshot^THESNAPSHOT');
+      conn.conn.sendMessage('SETS^var.currentCue^THECUE');
 
       conn.conn.sendMessage = vi.fn();
       conn.shows.updateCurrentCue();

--- a/packages/mixer-connection/src/lib/facade/volume-bus.ts
+++ b/packages/mixer-connection/src/lib/facade/volume-bus.ts
@@ -79,8 +79,7 @@ export class VolumeBus implements FadeableChannel {
 
   private setFaderLevelRaw(value: number) {
     const bus = `${this.busName}${this.busId ? '.' + (this.busId - 1) : ''}`;
-    const command = `SETD^settings.${bus}^${value}`;
-    this.conn.sendMessage(command);
+    this.conn.setd(`settings.${bus}`, value);
   }
 
   /**

--- a/packages/mixer-connection/src/lib/mixer-connection.ts
+++ b/packages/mixer-connection/src/lib/mixer-connection.ts
@@ -223,4 +223,24 @@ export class MixerConnection {
   sendMessage(msg: string) {
     this.outboundSubject$.next(msg);
   }
+
+  /**
+   * Send a `SETD` command to the mixer.
+   * `SETD` messages carry numeric (data) values, e.g. fader levels, mute states or gains.
+   * @param path Parameter path, e.g. `i.2.mute`
+   * @param value Numeric value to set
+   */
+  setd(path: string, value: number) {
+    this.sendMessage(`SETD^${path}^${value}`);
+  }
+
+  /**
+   * Send a `SETS` command to the mixer.
+   * `SETS` messages carry string values, e.g. channel names.
+   * @param path Parameter path, e.g. `i.2.name`
+   * @param value String value to set
+   */
+  sets(path: string, value: string) {
+    this.sendMessage(`SETS^${path}^${value}`);
+  }
 }

--- a/packages/mixer-connection/src/lib/soundcraft-ui.ts
+++ b/packages/mixer-connection/src/lib/soundcraft-ui.ts
@@ -160,7 +160,7 @@ export class SoundcraftUI {
 
   /** Unmute all mute groups, "MUTE ALL" and "MUTE FX" */
   clearMuteGroups() {
-    this.conn.sendMessage('SETD^mgmask^0');
+    this.conn.setd('mgmask', 0);
   }
 
   /**

--- a/packages/mixer-connection/src/lib/state/mixer-store.spec.ts
+++ b/packages/mixer-connection/src/lib/state/mixer-store.spec.ts
@@ -58,12 +58,33 @@ describe('Mixer Store', () => {
       });
     });
 
+    it('should convert SETD values to numbers (int and float, incl. negative)', async () => {
+      sendMessage('SETD^i.3.mute^1');
+      sendMessage('SETD^i.3.mix^0.5236732');
+      sendMessage('SETD^i.3.pan^-0.25');
+      expect(await firstValueFrom(mixerStore.state$)).toEqual({
+        'i.3.mute': 1,
+        'i.3.mix': 0.5236732,
+        'i.3.pan': -0.25,
+      });
+    });
+
+    it('should keep SETS values as strings even when they look numeric', async () => {
+      sendMessage('SETS^i.3.name^34534');
+      sendMessage('SETS^var.mtk.session^0004');
+      expect(await firstValueFrom(mixerStore.state$)).toEqual({
+        'i.3.name': '34534',
+        'var.mtk.session': '0004',
+      });
+    });
+
     it('should ignore messages other than SETD or SETS', async () => {
-      sendMessage('SETD^abc^def');
+      sendMessage('SETD^abc^1');
+      sendMessage('SETS^def^ghi');
 
       sendMessage('FOO^bar^baz');
       sendMessage('XYZ^xyz^xyz');
-      expect(await firstValueFrom(mixerStore.state$)).toEqual({ abc: 'def' });
+      expect(await firstValueFrom(mixerStore.state$)).toEqual({ abc: 1, def: 'ghi' });
     });
   });
 });

--- a/packages/mixer-connection/src/lib/state/mixer-store.ts
+++ b/packages/mixer-connection/src/lib/state/mixer-store.ts
@@ -1,6 +1,5 @@
 import { connectable, filter, map, ReplaySubject, scan, share } from 'rxjs';
 
-import { transformStringValue } from '../utils';
 import { MixerConnection } from '../mixer-connection';
 import { ObjectStore } from './object-store';
 
@@ -9,7 +8,7 @@ export class MixerStore {
   private setdSetsMessageMatches$ = this.conn.allMessages$.pipe(
     map(msg => msg.match(/(SETD|SETS)\^([a-zA-Z0-9.]+)\^(.*)/)),
     filter((e): e is RegExpMatchArray => e !== null),
-    share()
+    share(),
   );
 
   /** Stream of raw SETD and SETS messages */
@@ -19,16 +18,17 @@ export class MixerStore {
   readonly state$ = connectable(
     this.setdSetsMessageMatches$.pipe(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      scan((acc: any, [, , path, value]) => {
+      scan((acc: any, [, type, path, value]) => {
+        // SETD always carries numeric values, SETS always carries strings.
         // mutable implementation
-        acc[path] = transformStringValue(value);
+        acc[path] = type === 'SETD' ? Number(value) : value;
         return acc;
 
         // Alternative immutable implementation
-        // return { ...acc, [path]: transformStringValue(value) };
-      }, {})
+        // return { ...acc, [path]: type === 'SETD' ? Number(value) : value };
+      }, {}),
     ),
-    { connector: () => new ReplaySubject(1) }
+    { connector: () => new ReplaySubject(1) },
   );
 
   /**
@@ -42,10 +42,10 @@ export class MixerStore {
       map(message => message.slice(10).split('^')),
       scan(
         (acc, [syncId, index]) => ({ ...acc, [syncId]: parseInt(index, 10) }),
-        {} as Record<string, number>
-      )
+        {} as Record<string, number>,
+      ),
     ),
-    { connector: () => new ReplaySubject(1) }
+    { connector: () => new ReplaySubject(1) },
   );
 
   readonly objectStore = new ObjectStore();

--- a/packages/mixer-connection/src/lib/test.utils.ts
+++ b/packages/mixer-connection/src/lib/test.utils.ts
@@ -3,5 +3,5 @@ import { MixerModel } from './types';
 
 /** Manually set mixer model for testing */
 export function setMixerModel(model: MixerModel, conn: SoundcraftUI) {
-  conn.conn.sendMessage('SETD^model^' + model);
+  conn.conn.sets('model', model);
 }

--- a/packages/mixer-connection/src/lib/utils.spec.ts
+++ b/packages/mixer-connection/src/lib/utils.spec.ts
@@ -9,7 +9,6 @@ import {
   playerTimeToString,
   roundToThreeDecimals,
   sanitizeChannelName,
-  transformStringValue,
 } from './utils';
 
 describe('utils', () => {
@@ -91,23 +90,6 @@ describe('utils', () => {
       expect(roundToThreeDecimals(1234567890.123 + Number.EPSILON)).toBe(1234567890.123);
       expect(roundToThreeDecimals(-1234567890.123)).toBe(-1234567890.123);
       expect(roundToThreeDecimals(-1234567890.123 + Number.EPSILON)).toBe(-1234567890.123);
-    });
-  });
-
-  describe('transformStringValue', () => {
-    it('should convert number string to int', () => {
-      expect(transformStringValue('123')).toBe(123);
-      expect(transformStringValue('3')).toBe(3);
-    });
-
-    it('should convert number string to float', () => {
-      expect(transformStringValue('3.141')).toBe(3.141);
-      expect(transformStringValue('0.5236732')).toBe(0.5236732);
-    });
-
-    it('should ignore unknown values', () => {
-      const value = 'hello world';
-      expect(transformStringValue(value)).toBe(value);
     });
   });
 

--- a/packages/mixer-connection/src/lib/utils.ts
+++ b/packages/mixer-connection/src/lib/utils.ts
@@ -13,20 +13,6 @@ export function roundToThreeDecimals(value: number): number {
 }
 
 /**
- * Transform a given value to int, float or string
- * @param value
- */
-export function transformStringValue(value: string) {
-  if (value.match(/^-?\d+$/)) {
-    return parseInt(value, 10);
-  } else if (value.match(/^\d+\.\d+$/)) {
-    return parseFloat(value);
-  } else {
-    return value;
-  }
-}
-
-/**
  * Transform player time in seconds to human-readable format M:SS
  * @param value player time in seconds
  */


### PR DESCRIPTION
## Summary

Two related commits around SETD/SETS message handling:

1. **fix: only convert SETD values to numbers, keep SETS as strings**
   - `SETD` messages always carry numeric values; `SETS` always carry strings.
   - The state reducer previously ran every value through a numeric-coercion helper, which corrupted numeric-looking string values (e.g. session name `"0004"` became `4`, channel name `"34534"` became a number).
   - Now `Number(value)` is applied only to `SETD`; `SETS` values pass through untouched. As a bonus, `Number()` also handles negative floats that the old regex helper missed.
   - Removed the now-unused `transformStringValue` helper.

2. **refactor: add setd()/sets() helpers and use them across facades**
   - Added typed `setd(path, value: number)` and `sets(path, value: string)` methods to `MixerConnection`.
   - Replaced hand-built `SETD^…`/`SETS^…` command strings throughout the facades with these helpers, making the numeric-vs-string distinction explicit at every call site.

## Verification

The conversion fix was validated against a real-mixer capture of **6665** inbound messages:
- **6025** `SETD` messages — **0** carried a non-numeric value.
- **4** `SETS` messages carried numeric-looking values that were previously being mis-converted (now fixed), incl. `var.mtk.session^0004` which was losing its leading zeros.

- `npx nx test mixer-connection` ✅
- `npx nx lint mixer-connection` ✅
- `npx nx format:check` ✅