### PR TITLE
refactor!: make facade observable properties readonly, hide fullChannelId

### DIFF
--- a/packages/mixer-connection/src/lib/facade/automix-controller.ts
+++ b/packages/mixer-connection/src/lib/facade/automix-controller.ts
@@ -8,7 +8,7 @@ export type AutomixGroupId = 'a' | 'b';
 
 export class AutomixGroup {
   /** Active state of this automix group (`0` or `1`) */
-  state$ = this.store.state$.pipe(selectRawValue<number>(`automix.${this.group}.on`));
+  readonly state$ = this.store.state$.pipe(selectRawValue<number>(`automix.${this.group}.on`));
 
   constructor(
     private conn: MixerConnection,
@@ -41,10 +41,10 @@ export class AutomixGroup {
  */
 export class AutomixController {
   /** Global response time (linear, between `0` and `1`) */
-  responseTime$ = this.store.state$.pipe(selectRawValue<number>('automix.time'));
+  readonly responseTime$ = this.store.state$.pipe(selectRawValue<number>('automix.time'));
 
   /** Global response time in milliseconds (between `20` and `4000` ms) */
-  responseTimeMs$ = this.responseTime$.pipe(map(v => faderValueToTimeMs(v)));
+  readonly responseTimeMs$ = this.responseTime$.pipe(map(v => faderValueToTimeMs(v)));
 
   /**
    * Set global response time (linear)

--- a/packages/mixer-connection/src/lib/facade/aux-bus.ts
+++ b/packages/mixer-connection/src/lib/facade/aux-bus.ts
@@ -16,7 +16,7 @@ export class AuxBus {
    * Whether this AUX bus is currently configured as a matrix bus (Ui24R only).
    * When `true`, this slot is a matrix and should be controlled through `conn.mtx(n)` instead.
    */
-  isMatrix$ = this.store.state$.pipe(select(selectMatrix(this.bus)), map(Boolean));
+  readonly isMatrix$ = this.store.state$.pipe(select(selectMatrix(this.bus)), map(Boolean));
 
   constructor(
     private conn: MixerConnection,

--- a/packages/mixer-connection/src/lib/facade/aux-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/aux-channel.ts
@@ -16,12 +16,12 @@ export class AuxChannel extends SendChannel implements PannableChannel, PostProc
   private auxLinkChannelIds: string[] = [];
 
   /** PAN value of the AUX channel (between `0` and `1`) */
-  pan$ = this.store.state$.pipe(
+  readonly pan$ = this.store.state$.pipe(
     select(selectPan(this.channelType, this.channel, this.busType, this.bus)),
   );
 
   /** PRE/POST PROC value of the AUX channel (`1` (POST PROC) or `0` (PRE PROC)) */
-  postProc$ = this.store.state$.pipe(
+  readonly postProc$ = this.store.state$.pipe(
     select(selectPostProc(this.channelType, this.channel, this.busType, this.bus)),
   );
 

--- a/packages/mixer-connection/src/lib/facade/channel.ts
+++ b/packages/mixer-connection/src/lib/facade/channel.ts
@@ -29,7 +29,7 @@ import { joinStatePath } from '../utils/state-utils';
  * Represents a single channel with a fader
  */
 export class Channel implements FadeableChannel {
-  fullChannelId = `${this.channelType}.${this.channel - 1}`;
+  protected fullChannelId = `${this.channelType}.${this.channel - 1}`;
   protected faderLevelCommand = 'mix';
   protected linkedChannelIds: string[] = [];
 
@@ -41,15 +41,15 @@ export class Channel implements FadeableChannel {
   );
 
   /** Linear level of the channel (between `0` and `1`) */
-  faderLevel$ = this.store.state$.pipe(
+  readonly faderLevel$ = this.store.state$.pipe(
     select(selectFaderValue(this.channelType, this.channel, this.busType, this.bus)),
   );
 
   /** dB level of the channel (between `-Infinity` and `10`) */
-  faderLevelDB$ = this.faderLevel$.pipe(map(v => faderValueToDB(v)));
+  readonly faderLevelDB$ = this.faderLevel$.pipe(map(v => faderValueToDB(v)));
 
   /** MUTE value of the channel (`0` or `1`) */
-  mute$ = this.store.state$.pipe(
+  readonly mute$ = this.store.state$.pipe(
     select(selectMute(this.channelType, this.channel, this.busType, this.bus)),
   );
 
@@ -61,7 +61,7 @@ export class Channel implements FadeableChannel {
 
   private auxIsMatrix$ = this.store.state$.pipe(select(selectMatrix(this.channel)));
 
-  name$ = iif(
+  readonly name$ = iif(
     () => this.channelType !== 'a',
     this.rawName$.pipe(map(name => name || getDefaultChannelName(this.channelType, this.channel))),
     // an AUX slot can be switched into a matrix bus (Ui24R), which uses a different default name

--- a/packages/mixer-connection/src/lib/facade/delayable-master-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/delayable-master-channel.ts
@@ -12,7 +12,9 @@ import { MasterChannel } from './master-channel';
  */
 export class DelayableMasterChannel extends MasterChannel {
   /** Delay value of the channel (between `0` and `500` ms) */
-  delay$ = this.store.state$.pipe(select(selectDelayValue(this.channelType, this.channel)));
+  readonly delay$ = this.store.state$.pipe(
+    select(selectDelayValue(this.channelType, this.channel)),
+  );
 
   /** default delay value (ms) for input channels */
   private delayMaxValueMs = 250;

--- a/packages/mixer-connection/src/lib/facade/device-info.ts
+++ b/packages/mixer-connection/src/lib/facade/device-info.ts
@@ -9,13 +9,13 @@ export class DeviceInfo {
    * Hardware model of the mixer.
    * Possible values: `ui12`, `ui16`, `ui24`
    */
-  model$ = this.store.state$.pipe(selectRawValue<MixerModel>('model'));
+  readonly model$ = this.store.state$.pipe(selectRawValue<MixerModel>('model'));
 
   /** Device capabilities based on the model */
-  capabilities$ = this.model$.pipe(map(model => DEVICE_CAPABILITIES[model]));
+  readonly capabilities$ = this.model$.pipe(map(model => DEVICE_CAPABILITIES[model]));
 
   /** Firmware version of the mixer */
-  firmware$ = this.store.state$.pipe(selectRawValue<string>('firmware'));
+  readonly firmware$ = this.store.state$.pipe(selectRawValue<string>('firmware'));
 
   /**
    * Hardware model of the mixer.

--- a/packages/mixer-connection/src/lib/facade/dual-track-recorder.ts
+++ b/packages/mixer-connection/src/lib/facade/dual-track-recorder.ts
@@ -8,12 +8,15 @@ import { selectRawValue } from '../state/state-selectors';
  */
 export class DualTrackRecorder {
   /** Recording state (`0` or `1`) */
-  recording$ = this.store.state$.pipe(selectRawValue('var.isRecording', 0));
+  readonly recording$ = this.store.state$.pipe(selectRawValue('var.isRecording', 0));
 
   /** Recording busy state (`0` or `1`) */
-  busy$ = this.store.state$.pipe(selectRawValue('var.recBusy', 0));
+  readonly busy$ = this.store.state$.pipe(selectRawValue('var.recBusy', 0));
 
-  constructor(private conn: MixerConnection, private store: MixerStore) {}
+  constructor(
+    private conn: MixerConnection,
+    private store: MixerStore,
+  ) {}
 
   /** Toggle recording */
   recordToggle() {

--- a/packages/mixer-connection/src/lib/facade/fx-bus.ts
+++ b/packages/mixer-connection/src/lib/facade/fx-bus.ts
@@ -13,13 +13,13 @@ export class FxBus {
    * Selected FX type (Reverb, Delay, Chorus, Room).
    * The numeric value can be matched using the `FxType` enum.
    */
-  fxType$ = this.store.state$.pipe(select(selectFxType(this.bus)));
+  readonly fxType$ = this.store.state$.pipe(select(selectFxType(this.bus)));
 
   /**
    * BPM value of this FX.
    * This setting is always present but might not be actually used if the selected FX does not have a BPM setting.
    */
-  bpm$ = this.store.state$.pipe(select(selectFxBpm(this.bus)));
+  readonly bpm$ = this.store.state$.pipe(select(selectFxBpm(this.bus)));
 
   constructor(
     private conn: MixerConnection,

--- a/packages/mixer-connection/src/lib/facade/hw-channel.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/hw-channel.spec.ts
@@ -22,17 +22,17 @@ describe('AUX Channel', () => {
   describe('Channel ID for different hardware models', () => {
     it('should use `hw` for ui24', () => {
       setMixerModel('ui24', conn);
-      expect(conn.hw(4).fullChannelId).toBe('hw.3');
+      expect(conn.hw(4)['fullChannelId']).toBe('hw.3');
     });
 
     it('should use `i` for ui16', () => {
       setMixerModel('ui16', conn);
-      expect(conn.hw(6).fullChannelId).toBe('i.5');
+      expect(conn.hw(6)['fullChannelId']).toBe('i.5');
     });
 
     it('should use `i` for ui12', () => {
       setMixerModel('ui12', conn);
-      expect(conn.hw(4).fullChannelId).toBe('i.3');
+      expect(conn.hw(4)['fullChannelId']).toBe('i.3');
     });
   });
 

--- a/packages/mixer-connection/src/lib/facade/hw-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/hw-channel.ts
@@ -13,10 +13,10 @@ import { DeviceInfo } from './device-info';
  * Represents a hardware input on the mixer
  */
 export class HwChannel {
-  fullChannelId = `hw.${this.channel - 1}`;
+  protected fullChannelId = `hw.${this.channel - 1}`;
 
   /** Phantom power state of the channel (`0` or `1`) */
-  phantom$ = this.deviceInfo.model$.pipe(
+  readonly phantom$ = this.deviceInfo.model$.pipe(
     switchMap(model => {
       switch (model) {
         case 'ui24':
@@ -29,7 +29,7 @@ export class HwChannel {
   );
 
   /** Linear gain level of the channel (between `0` and `1`) */
-  gain$ = this.deviceInfo.model$.pipe(
+  readonly gain$ = this.deviceInfo.model$.pipe(
     switchMap(model => {
       switch (model) {
         case 'ui24':
@@ -42,7 +42,7 @@ export class HwChannel {
   );
 
   /** dB gain level of the channel */
-  gainDB$ = this.deviceInfo.model$.pipe(
+  readonly gainDB$ = this.deviceInfo.model$.pipe(
     switchMap(model => {
       switch (model) {
         case 'ui24':

--- a/packages/mixer-connection/src/lib/facade/interfaces.ts
+++ b/packages/mixer-connection/src/lib/facade/interfaces.ts
@@ -3,10 +3,10 @@ import { Easings } from '../utils/transitions/easings';
 
 export interface FadeableChannel {
   /** Name of the channel */
-  name$: Observable<string>;
+  readonly name$: Observable<string>;
 
-  faderLevel$: Observable<number>;
-  faderLevelDB$: Observable<number>;
+  readonly faderLevel$: Observable<number>;
+  readonly faderLevelDB$: Observable<number>;
 
   fadeTo(targetValue: number, fadeTime: number, easing: Easings, fps?: number): Promise<void>;
 
@@ -20,7 +20,7 @@ export interface FadeableChannel {
 }
 
 export interface PannableChannel {
-  pan$: Observable<number>;
+  readonly pan$: Observable<number>;
 
   setPan(value: number): void;
   changePan(offset: number): void;
@@ -28,7 +28,7 @@ export interface PannableChannel {
 
 export interface PostProcessableChannel {
   /** PRE/POST PROC value of the channel (`1` (POST PROC) or `0` (PRE PROC)) */
-  postProc$: Observable<number>;
+  readonly postProc$: Observable<number>;
 
   setPostProc(value: number): void;
   postProc(): void;

--- a/packages/mixer-connection/src/lib/facade/master-bus.ts
+++ b/packages/mixer-connection/src/lib/facade/master-bus.ts
@@ -23,24 +23,24 @@ import { MasterChannel } from './master-channel';
  * Represents the master bus
  */
 export class MasterBus implements FadeableChannel, PannableChannel {
-  name$ = of('MASTER');
+  readonly name$ = of('MASTER');
 
   /** Linear level of the master fader (between `0` and `1`) */
-  faderLevel$ = this.store.state$.pipe(select(selectMasterValue()));
+  readonly faderLevel$ = this.store.state$.pipe(select(selectMasterValue()));
 
   /** dB level of the master fader (between `-Infinity` and `10`) */
-  faderLevelDB$ = this.faderLevel$.pipe(map(v => faderValueToDB(v)));
+  readonly faderLevelDB$ = this.faderLevel$.pipe(map(v => faderValueToDB(v)));
 
   /** PAN value of the master (between `0` and `1`) */
-  pan$ = this.store.state$.pipe(select(selectMasterPan()));
+  readonly pan$ = this.store.state$.pipe(select(selectMasterPan()));
 
   /** DIM value of the master (`0` or `1`) */
-  dim$ = this.store.state$.pipe(select(selectMasterDim()));
+  readonly dim$ = this.store.state$.pipe(select(selectMasterDim()));
 
   /** LEFT DELAY (ms) of the master */
-  delayL$ = this.store.state$.pipe(select(selectMasterDelay('L')));
+  readonly delayL$ = this.store.state$.pipe(select(selectMasterDelay('L')));
   /** RIGHT DELAY (ms) of the master */
-  delayR$ = this.store.state$.pipe(select(selectMasterDelay('R')));
+  readonly delayR$ = this.store.state$.pipe(select(selectMasterDelay('R')));
 
   private transitionSources$ = new Subject<TransitionSource>();
 

--- a/packages/mixer-connection/src/lib/facade/master-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/master-channel.ts
@@ -18,19 +18,19 @@ import {
  * Represents a channel on the master bus
  */
 export class MasterChannel extends Channel implements PannableChannel {
-  override fullChannelId = constructMasterChannelId(this.channelType, this.channel);
+  protected override fullChannelId = constructMasterChannelId(this.channelType, this.channel);
   override faderLevelCommand = 'mix';
 
   /** SOLO value of the channel (`0` or `1`) */
-  solo$ = this.store.state$.pipe(select(selectSolo(this.channelType, this.channel)));
+  readonly solo$ = this.store.state$.pipe(select(selectSolo(this.channelType, this.channel)));
 
   /** PAN value of the channel (between `0` and `1`) */
-  pan$ = this.store.state$.pipe(
+  readonly pan$ = this.store.state$.pipe(
     select(selectPan(this.channelType, this.channel, this.busType, this.bus)),
   );
 
   /** Assigned automix group (`a`, `b`, `none`) */
-  automixGroup$ = this.store.state$.pipe(
+  readonly automixGroup$ = this.store.state$.pipe(
     selectRawValue<number>(`${this.fullChannelId}.amixgroup`),
     map((groupId): AutomixGroupId | 'none' => {
       switch (groupId) {
@@ -45,13 +45,17 @@ export class MasterChannel extends Channel implements PannableChannel {
   );
 
   /** Automix weight (linear) for this channel (between `0` and `1`) */
-  automixWeight$ = this.store.state$.pipe(selectRawValue<number>(`${this.fullChannelId}.amix`));
+  readonly automixWeight$ = this.store.state$.pipe(
+    selectRawValue<number>(`${this.fullChannelId}.amix`),
+  );
 
   /** Automix weight (dB) for this channel (between `-12` and `12` dB) */
-  automixWeightDB$ = this.automixWeight$.pipe(map(v => linearMappingValueToRange(v, -12, 12)));
+  readonly automixWeightDB$ = this.automixWeight$.pipe(
+    map(v => linearMappingValueToRange(v, -12, 12)),
+  );
 
   /** Multitrack selection state for the channel (`0` or `1`) */
-  multiTrackSelected$ = this.store.state$.pipe(
+  readonly multiTrackSelected$ = this.store.state$.pipe(
     selectRawValue<number>(`${this.fullChannelId}.mtkrec`),
   );
 

--- a/packages/mixer-connection/src/lib/facade/mtx-bus-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/mtx-bus-channel.ts
@@ -15,7 +15,7 @@ import { MtxChannel } from './mtx-channel';
  */
 export class MtxBusChannel extends MtxChannel {
   // Channel name is only available directly in the channel, e.g. `a.1.name`.
-  name$ = this.store.state$.pipe(
+  readonly name$ = this.store.state$.pipe(
     selectRawValue<string>(joinStatePath(this.channelType, this.channel - 1, 'name')),
     map(name => name || getDefaultChannelName(this.channelType, this.channel)),
   );

--- a/packages/mixer-connection/src/lib/facade/mtx-bus.ts
+++ b/packages/mixer-connection/src/lib/facade/mtx-bus.ts
@@ -20,7 +20,7 @@ import { auxBusStoreId } from './object-store-ids';
  */
 export class MtxBus {
   /** Whether this bus is currently configured as a matrix bus (Ui24R only) */
-  isMatrix$ = this.store.state$.pipe(select(selectMatrix(this.bus)), map(Boolean));
+  readonly isMatrix$ = this.store.state$.pipe(select(selectMatrix(this.bus)), map(Boolean));
 
   constructor(
     private conn: MixerConnection,

--- a/packages/mixer-connection/src/lib/facade/mtx-master-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/mtx-master-channel.ts
@@ -13,7 +13,7 @@ import { MtxChannel } from './mtx-channel';
  * Matrix buses are only available on the Ui24R.
  */
 export class MtxMasterChannel extends MtxChannel {
-  name$ = of('MASTER');
+  readonly name$ = of('MASTER');
 
   constructor(conn: MixerConnection, store: MixerStore, bus: number) {
     super(conn, store, `m.mtx.${bus - 1}`);

--- a/packages/mixer-connection/src/lib/facade/multi-track-recorder.ts
+++ b/packages/mixer-connection/src/lib/facade/multi-track-recorder.ts
@@ -15,12 +15,12 @@ import { MtkState } from '../types';
  */
 export class MultiTrackRecorder {
   /** Current state (playing, stopped, paused) */
-  state$ = this.store.state$.pipe(
+  readonly state$ = this.store.state$.pipe(
     selectRawValue<MtkState>('var.mtk.currentState', MtkState.Stopped),
   );
 
   /** Current session name (e.g. `0001` or individual name) */
-  session$ = this.store.state$.pipe(
+  readonly session$ = this.store.state$.pipe(
     selectRawValue<number | string>('var.mtk.session'),
     map(value => {
       if (typeof value === 'number') {
@@ -33,29 +33,29 @@ export class MultiTrackRecorder {
   );
 
   /** Current session length in seconds */
-  length$ = this.store.state$.pipe(select(selectMtkLength()));
+  readonly length$ = this.store.state$.pipe(select(selectMtkLength()));
 
   /** Elapsed time of current session in seconds */
-  elapsedTime$ = this.store.state$.pipe(select(selectMtkElapsedTime()));
+  readonly elapsedTime$ = this.store.state$.pipe(select(selectMtkElapsedTime()));
 
   /** Remaining time of current session in seconds */
-  remainingTime$ = this.store.state$.pipe(select(selectMtkRemainingTime()));
+  readonly remainingTime$ = this.store.state$.pipe(select(selectMtkRemainingTime()));
 
   /** Recording state (`0` or `1`) */
-  recording$ = this.store.state$.pipe(selectRawValue('var.mtk.rec.currentState', 0));
+  readonly recording$ = this.store.state$.pipe(selectRawValue('var.mtk.rec.currentState', 0));
 
   /** Recording busy state (`0` or `1`) */
-  busy$ = this.store.state$.pipe(selectRawValue('var.mtk.rec.busy', 0));
+  readonly busy$ = this.store.state$.pipe(selectRawValue('var.mtk.rec.busy', 0));
 
   /** Recording time in seconds */
-  recordingTime$ = this.store.state$.pipe(
+  readonly recordingTime$ = this.store.state$.pipe(
     selectRawValue('var.mtk.rec.time', 0),
     withLatestFrom(this.recording$),
     map(([value, recording]) => (recording ? value : 0)), // set to 0 if not actually recording. otherwise, it emits strange values
   );
 
   /** Soundcheck activation state (`0` or `1`) */
-  soundcheck$ = this.store.state$.pipe(selectRawValue('var.mtk.soundcheck', 0));
+  readonly soundcheck$ = this.store.state$.pipe(selectRawValue('var.mtk.soundcheck', 0));
 
   constructor(
     private conn: MixerConnection,

--- a/packages/mixer-connection/src/lib/facade/mute-group.ts
+++ b/packages/mixer-connection/src/lib/facade/mute-group.ts
@@ -35,7 +35,7 @@ export class MuteGroup {
   private mgMask$ = this.store.state$.pipe(selectRawValue<number>('mgmask'));
 
   /** MUTE state of the group (`0` or `1`) */
-  state$ = this.mgMask$.pipe(map(value => getValueOfBit(value, this.groupIndex)));
+  readonly state$ = this.mgMask$.pipe(map(value => getValueOfBit(value, this.groupIndex)));
 
   /** Mute the MUTE group */
   mute() {

--- a/packages/mixer-connection/src/lib/facade/player.ts
+++ b/packages/mixer-connection/src/lib/facade/player.ts
@@ -16,27 +16,27 @@ import { PlayerState } from '../types';
  */
 export class Player {
   /** Current state (playing, stopped, paused) */
-  state$ = this.store.state$.pipe(
+  readonly state$ = this.store.state$.pipe(
     selectRawValue<PlayerState>('var.currentState', PlayerState.Stopped),
   );
 
   /** Current playlist name */
-  playlist$ = this.store.state$.pipe(selectRawValue<string>('var.currentPlaylist'));
+  readonly playlist$ = this.store.state$.pipe(selectRawValue<string>('var.currentPlaylist'));
 
   /** Current track name */
-  track$ = this.store.state$.pipe(selectRawValue<string>('var.currentTrack'));
+  readonly track$ = this.store.state$.pipe(selectRawValue<string>('var.currentTrack'));
 
   /** Current track length in seconds */
-  length$ = this.store.state$.pipe(select(selectPlayerLength()));
+  readonly length$ = this.store.state$.pipe(select(selectPlayerLength()));
 
   /** Elapsed time of current track in seconds */
-  elapsedTime$ = this.store.state$.pipe(select(selectPlayerElapsedTime()));
+  readonly elapsedTime$ = this.store.state$.pipe(select(selectPlayerElapsedTime()));
 
   /** Remaining time of current track in seconds */
-  remainingTime$ = this.store.state$.pipe(select(selectPlayerRemainingTime()));
+  readonly remainingTime$ = this.store.state$.pipe(select(selectPlayerRemainingTime()));
 
   /** Shuffle setting (`0` or `1`) */
-  shuffle$ = this.store.state$.pipe(selectRawValue('settings.shuffle', 0));
+  readonly shuffle$ = this.store.state$.pipe(selectRawValue('settings.shuffle', 0));
 
   constructor(
     private conn: MixerConnection,

--- a/packages/mixer-connection/src/lib/facade/send-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/send-channel.ts
@@ -12,7 +12,7 @@ import { constructSendChannelId } from './channel-id';
  * Used as super class for Aux and Fx
  */
 export class SendChannel extends Channel {
-  override fullChannelId = constructSendChannelId(
+  protected override fullChannelId = constructSendChannelId(
     this.channelType,
     this.channel,
     this.busType,
@@ -21,7 +21,7 @@ export class SendChannel extends Channel {
   override faderLevelCommand = 'value';
 
   /** PRE/POST value of the channel (`1` (POST) or `0` (PRE)) */
-  post$ = this.store.state$.pipe(
+  readonly post$ = this.store.state$.pipe(
     select(selectPost(this.channelType, this.channel, this.busType, this.bus)),
   );
 

--- a/packages/mixer-connection/src/lib/facade/show-controller.ts
+++ b/packages/mixer-connection/src/lib/facade/show-controller.ts
@@ -8,15 +8,18 @@ import { selectRawValue } from '../state/state-selectors';
  */
 export class ShowController {
   /** Currently loaded show */
-  currentShow$ = this.store.state$.pipe(selectRawValue<string>('var.currentShow'));
+  readonly currentShow$ = this.store.state$.pipe(selectRawValue<string>('var.currentShow'));
 
   /** Currently loaded snapshot */
-  currentSnapshot$ = this.store.state$.pipe(selectRawValue<string>('var.currentSnapshot'));
+  readonly currentSnapshot$ = this.store.state$.pipe(selectRawValue<string>('var.currentSnapshot'));
 
   /** Currently loaded cue */
-  currentCue$ = this.store.state$.pipe(selectRawValue<string>('var.currentCue'));
+  readonly currentCue$ = this.store.state$.pipe(selectRawValue<string>('var.currentCue'));
 
-  constructor(private conn: MixerConnection, private store: MixerStore) {}
+  constructor(
+    private conn: MixerConnection,
+    private store: MixerStore,
+  ) {}
 
   /**
    * Load a show by name
@@ -67,7 +70,7 @@ export class ShowController {
     combineLatest([this.currentShow$, this.currentSnapshot$])
       .pipe(
         take(1),
-        filter(([show, snapshot]) => !!show && !!snapshot)
+        filter(([show, snapshot]) => !!show && !!snapshot),
       )
       .subscribe(([show, snapshot]) => this.saveSnapshot(show, snapshot));
   }
@@ -77,7 +80,7 @@ export class ShowController {
     combineLatest([this.currentShow$, this.currentCue$])
       .pipe(
         take(1),
-        filter(([show, cue]) => !!show && !!cue)
+        filter(([show, cue]) => !!show && !!cue),
       )
       .subscribe(([show, cue]) => this.saveCue(show, cue));
   }

--- a/packages/mixer-connection/src/lib/facade/volume-bus.ts
+++ b/packages/mixer-connection/src/lib/facade/volume-bus.ts
@@ -17,14 +17,14 @@ export class VolumeBus implements FadeableChannel {
   private transitionSources$ = new Subject<TransitionSource>();
 
   /** Linear level of the volume bus (between `0` and `1`) */
-  faderLevel$ = this.store.state$.pipe(
+  readonly faderLevel$ = this.store.state$.pipe(
     select(selectVolumeBusValue(this.busName, this.busId ? this.busId - 1 : undefined)),
   );
 
   /** dB level of the volume bus (between `-Infinity` and `10`) */
-  faderLevelDB$ = this.faderLevel$.pipe(map(v => faderValueToDB(v)));
+  readonly faderLevelDB$ = this.faderLevel$.pipe(map(v => faderValueToDB(v)));
 
-  name$ = of(getDefaultVolumeBusName(this.busName, this.busId || -1));
+  readonly name$ = of(getDefaultVolumeBusName(this.busName, this.busId || -1));
 
   constructor(
     protected conn: MixerConnection,

--- a/packages/testbed/src/app/pages/hwchannels-page/hwchannels-page.html
+++ b/packages/testbed/src/app/pages/hwchannels-page/hwchannels-page.html
@@ -1,5 +1,5 @@
 @for (channel of channels; track channel) {
-<h2 class="mt-5">HW Channel {{ channel.fullChannelId }}</h2>
+<h2 class="mt-5">HW Channel {{ $index + 1 }}</h2>
 <h3>Phantom Power</h3>
 <sui-mixer-button (press)="channel.phantomOn()">ON</sui-mixer-button>
 <sui-mixer-button (press)="channel.phantomOff()">OFF</sui-mixer-button>


### PR DESCRIPTION
## Summary

Makes the facade public API immutable and hides an internal implementation detail, bringing the sub-facades in line with the already fully-`readonly` `SoundcraftUI` entry point.

- **`readonly` on all public observables** across every facade class (`Channel`, `MasterBus`, `HwChannel`, `Player`, `MasterChannel`, etc.) plus the matching members in the `FadeableChannel` / `PannableChannel` / `PostProcessableChannel` interfaces.
- **`fullChannelId` is now `protected`** — it's an internal detail (reassigned at runtime in `HwChannel` based on the device model), so it can't be `readonly` and shouldn't be public.
- Fields genuinely reassigned at runtime (`linkedChannelIds`, `auxLinkChannelIds`, `panLinkChannelIds`) intentionally stay writable.

## Consumers updated
- `hw-channel.spec.ts` — the three external `fullChannelId` reads now use the protected-access pattern `conn.hw(n)['fullChannelId']`.
- `testbed` `hwchannels-page.html` — heading no longer reads `channel.fullChannelId`; shows the channel number via `$index + 1`.

## Breaking changes
- Public observable properties are now `readonly` and can no longer be reassigned.
- `fullChannelId` is now `protected` and no longer accessible from outside the facade classes.

## Verification
- `nx build/test/lint mixer-connection` → build + d.ts clean, **492 tests pass**, lint clean
- `nx build testbed` → succeeds
- `nx format:check` → clean