### PR TITLE
feat!: emit booleans for on/off state and accept booleans in setters

### DIFF
--- a/docs/docs/buses/aux-sends.md
+++ b/docs/docs/buses/aux-sends.md
@@ -24,12 +24,12 @@ An `AuxChannel` supports the following operations:
 | `pre()`                          | Set channel to PRE                                                    |
 | `post()`                         | Set channel to POST                                                   |
 | `togglePost()`                   | Toggle PRE/POST status                                                |
-| `setPost(value)`                 | Set POST (`1`) or PRE (`0`)                                           |
+| `setPost(value)`                 | Set POST (`true`) or PRE (`false`)                                    |
 | `preProc()`                      | Set channel to PRE PROC                                               |
 | `postProc()`                     | Set channel to POST PROC                                              |
-| `setPostProc(value)`             | Set POST PROC (`1`) or PRE PROC (`0`)                                 |
-| `post$`                          | Get POST status (`0` for PRE, `1` for POST)                           |
-| `postProc$`                      | Get POST PROC status (`0` for PRE PROC, `1` for POST PROC)            |
+| `setPostProc(value)`             | Set POST PROC (`true`) or PRE PROC (`false`)                          |
+| `post$`                          | Get POST status (`false` for PRE, `true` for POST)                    |
+| `postProc$`                      | Get POST PROC status (`false` for PRE PROC, `true` for POST PROC)     |
 | `pan$`                           | Get pan value (between `0` and `1`)                                   |
 
 On the Ui24R an AUX bus can be converted into a matrix bus.

--- a/docs/docs/buses/channel.md
+++ b/docs/docs/buses/channel.md
@@ -22,13 +22,13 @@ Therefore, these operations are available for any channel like `MasterChannel`, 
 
 ## Mute
 
-| Call             | Description                       |
-| ---------------- | --------------------------------- |
-| `setMute(value)` | Set mute for channel (`0` or `1`) |
-| `mute()`         | Mute channel                      |
-| `unmute()`       | Unmute channel                    |
-| `toggleMute()`   | Toggle mute status                |
-| `mute$`          | Get mute status (`0` or `1`)      |
+| Call             | Description          |
+| ---------------- | -------------------- |
+| `setMute(value)` | Set mute for channel |
+| `mute()`         | Mute channel         |
+| `unmute()`       | Unmute channel       |
+| `toggleMute()`   | Toggle mute status   |
+| `mute$`          | Get mute state       |
 
 ## Other operations
 

--- a/docs/docs/buses/fx-sends.md
+++ b/docs/docs/buses/fx-sends.md
@@ -16,13 +16,13 @@ Then pick one of the available `FxChannel`s:
 
 An `FxChannel` supports the following operations:
 
-| Call on `FxChannel`              | Description                                 |
-| -------------------------------- | ------------------------------------------- |
-| _all generic channel operations_ |                                             |
-| `post$`                          | Get POST status (`0` for PRE, `1` for POST) |
-| `pre()`                          | Set channel to PRE                          |
-| `post()`                         | Set channel to POST                         |
-| `setPost(value)`                 | Set POST (`1`) or PRE (`0`)                 |
+| Call on `FxChannel`              | Description                                        |
+| -------------------------------- | -------------------------------------------------- |
+| _all generic channel operations_ |                                                    |
+| `post$`                          | Get POST status (`false` for PRE, `true` for POST) |
+| `pre()`                          | Set channel to PRE                                 |
+| `post()`                         | Set channel to POST                                |
+| `setPost(value)`                 | Set POST (`true`) or PRE (`false`)                 |
 
 Settings for the FX processors can also be accessed through the `FxBus` class.
 See the separate [**FX Settings** docs page](../features/fx-settings) for this.

--- a/docs/docs/buses/hwchannel.md
+++ b/docs/docs/buses/hwchannel.md
@@ -19,13 +19,13 @@ First, get a `HwChannel` by calling `conn.hw(inputNumber)`, e.g. `conn.hw(1)` fo
 
 ## Phantom Power
 
-| Call on `HwChannel` | Description                           |
-| ------------------- | ------------------------------------- |
-| `phantom$`          | Get phantom power status (`0` or `1`) |
-| `phantomOn()`       | Switch ON phantom power               |
-| `phantomOff()`      | Switch OFF phantom power              |
-| `togglePhantom()`   | Toggle phantom power status           |
-| `setPhantom(value)` | Set phantom power status (`0` or `1`) |
+| Call on `HwChannel` | Description                 |
+| ------------------- | --------------------------- |
+| `phantom$`          | Get phantom power state     |
+| `phantomOn()`       | Switch ON phantom power     |
+| `phantomOff()`      | Switch OFF phantom power    |
+| `togglePhantom()`   | Toggle phantom power status |
+| `setPhantom(value)` | Set phantom power state     |
 
 ## Gain
 

--- a/docs/docs/buses/master-bus.md
+++ b/docs/docs/buses/master-bus.md
@@ -26,8 +26,8 @@ The `MasterChannel` exposes the following operations:
 | `pan$`                           | Get pan value (between `0` and `1`)       |
 | `setPan(value)`                  | Set pan for channel (between `0` and `1`) |
 | `changePan(offset)`              | Relatively change pan for channel         |
-| `solo$`                          | Get solo status (`0` or `1`)              |
-| `setSolo(value)`                 | Set solo for channel (`0` or `1`)         |
+| `solo$`                          | Get solo state                            |
+| `setSolo(value)`                 | Set solo for channel                      |
 | `solo()`                         | Enable solo                               |
 | `unsolo()`                       | Disable solo                              |
 | `toggleSolo()`                   | Toggle solo status                        |

--- a/docs/docs/buses/master.md
+++ b/docs/docs/buses/master.md
@@ -41,13 +41,13 @@ The following operations can be used to interact with the global master fader.
 
 ## DIM (Ui24R only)
 
-| Call on `MasterBus` | Description                        |
-| ------------------- | ---------------------------------- |
-| `dim$`              | Get master dim status (`0` or `1`) |
-| `dim()`             | Dim master                         |
-| `undim()`           | Undim master                       |
-| `toggleDim()`       | Toggle master dim                  |
-| `setDim(value)`     | Set master dim (`0` or `1`)        |
+| Call on `MasterBus` | Description          |
+| ------------------- | -------------------- |
+| `dim$`              | Get master dim state |
+| `dim()`             | Dim master           |
+| `undim()`           | Undim master         |
+| `toggleDim()`       | Toggle master dim    |
+| `setDim(value)`     | Set master dim       |
 
 ## Other operations
 

--- a/docs/docs/buses/matrix.md
+++ b/docs/docs/buses/matrix.md
@@ -69,9 +69,9 @@ A channel supports the following operations:
 | `changePan(offset)`              | Relatively change pan for channel. Not possible for mono MTX!         |
 | `preProc()`                      | Set channel to PRE PROC                                               |
 | `postProc()`                     | Set channel to POST PROC                                              |
-| `setPostProc(value)`             | Set POST PROC (`1`) or PRE PROC (`0`)                                 |
+| `setPostProc(value)`             | Set POST PROC (`true`) or PRE PROC (`false`)                          |
 | `pan$`                           | Get pan value (between `0` and `1`)                                   |
-| `postProc$`                      | Get POST PROC status (`0` for PRE PROC, `1` for POST PROC)            |
+| `postProc$`                      | Get POST PROC status (`false` for PRE PROC, `true` for POST PROC)     |
 
 :::note
 The master source (`MtxMasterChannel`) has a static name: `name$` always emits `MASTER` and there is no `setName()`.

--- a/docs/docs/features/automix.md
+++ b/docs/docs/features/automix.md
@@ -26,12 +26,12 @@ const groupB = conn.automix.groups.b;
 
 Each group exposes the following methods and properties:
 
-| Call on `AutomixGroup` | Description                                     |
-| ---------------------- | ----------------------------------------------- |
-| `enable()`             | Globally enable this automix group              |
-| `disable()`            | Globally disable this automix group             |
-| `toggle()`             | Toggle the state of this automix group          |
-| `state$`               | Active state of this automix group (`0` or `1`) |
+| Call on `AutomixGroup` | Description                            |
+| ---------------------- | -------------------------------------- |
+| `enable()`             | Globally enable this automix group     |
+| `disable()`            | Globally disable this automix group    |
+| `toggle()`             | Toggle the state of this automix group |
+| `state$`               | Active state of this automix group     |
 
 ## Automix Channel Assignment
 

--- a/docs/docs/features/mutegroups.md
+++ b/docs/docs/features/mutegroups.md
@@ -18,12 +18,12 @@ First, get access to a `MuteGroup` object:
 
 `MuteGroup` supports the following operations:
 
-| Call on `MuteGroup` | Description                  |
-| ------------------- | ---------------------------- |
-| `state$`            | Get MUTE status (`0` or `1`) |
-| `mute()`            | Mute the group               |
-| `unmute()`          | Unmute the group             |
-| `toggle()`          | Toggle mute group            |
+| Call on `MuteGroup` | Description       |
+| ------------------- | ----------------- |
+| `state$`            | Get MUTE state    |
+| `mute()`            | Mute the group    |
+| `unmute()`          | Unmute the group  |
+| `toggle()`          | Toggle mute group |
 
 Call `conn.clearMuteGroups()` to disable all MUTE groups.
 This behaves differently from the "CLEAR MUTE" button in the Soundcraft Web App which also clears channel mutes.

--- a/docs/docs/recording-playback/dualtrack.md
+++ b/docs/docs/recording-playback/dualtrack.md
@@ -7,10 +7,10 @@ sidebar_position: 1
 The following commands control the dual-track USB recorder in the media player section.
 The `DualTrackRecorder` object can be accessed through `conn.recorderDualTrack`.
 
-| Call on `DualTrackRecorder` | Description                       |
-| --------------------------- | --------------------------------- |
-| `recording$`                | Recording state (`0` or `1`)      |
-| `busy$`                     | Recording busy state (`0` or `1`) |
-| `recordToggle()`            | Toggle recording                  |
-| `recordStart()`             | Start recording                   |
-| `recordStop()`              | Stop recording                    |
+| Call on `DualTrackRecorder` | Description          |
+| --------------------------- | -------------------- |
+| `recording$`                | Recording state      |
+| `busy$`                     | Recording busy state |
+| `recordToggle()`            | Toggle recording     |
+| `recordStart()`             | Start recording      |
+| `recordStop()`              | Stop recording       |

--- a/docs/docs/recording-playback/media-player.md
+++ b/docs/docs/recording-playback/media-player.md
@@ -14,7 +14,7 @@ The Media Player can be accessed through `conn.player`. This object exposes the 
 | `length$`                    | Current track length in seconds                                                                              |
 | `elapsedTime$`               | Elapsed time of current track in seconds                                                                     |
 | `remainingTime$`             | Remaining time of current track in seconds                                                                   |
-| `shuffle$`                   | Shuffle setting (`0` or `1`)                                                                                 |
+| `shuffle$`                   | Shuffle state                                                                                                |
 | `play()`                     | Play                                                                                                         |
 | `pause()`                    | Pause                                                                                                        |
 | `stop()`                     | Stop                                                                                                         |
@@ -22,8 +22,8 @@ The Media Player can be accessed through `conn.player`. This object exposes the 
 | `prev()`                     | Previous track                                                                                               |
 | `loadPlaylist(playlist)`     | Load a playlist by name. `playlist` is the name of the playlist/folder                                       |
 | `loadTrack(track, playlist)` | Load a track from a given playlist. `track` and `playlist` are the file/folder names as seen in the Web UI.  |
-| `setShuffle(value)`          | Set player shuffle setting (`0` or `1`)                                                                      |
-| `toggleShuffle()`            | Toggle player shuffle setting                                                                                |
+| `setShuffle(value)`          | Set player shuffle state                                                                                     |
+| `toggleShuffle()`            | Toggle player shuffle state                                                                                  |
 | `setPlayMode(value)`         | Set player mode like `manual` or `auto`. Values are rather internal, please use convenience functions below. |
 | `setManual()`                | Enable manual mode                                                                                           |
 | `setAuto()`                  | Enable automatic                                                                                             |

--- a/docs/docs/recording-playback/multitrack.md
+++ b/docs/docs/recording-playback/multitrack.md
@@ -14,8 +14,8 @@ It supports the following operations:
 | `length$`                    | Current session length in seconds                                                                                                             |
 | `elapsedTime$`               | Elapsed time of current session in seconds                                                                                                    |
 | `remainingTime$`             | Remaining time of current session in seconds                                                                                                  |
-| `recording$`                 | Recording state (`0` or `1`)                                                                                                                  |
-| `busy$`                      | Recording busy state (`0` or `1`)                                                                                                             |
+| `recording$`                 | Recording state                                                                                                                               |
+| `busy$`                      | Recording busy state                                                                                                                          |
 | `recordingTime$`             | Recording time in seconds                                                                                                                     |
 | `soundcheck$`                | Soundcheck activation state                                                                                                                   |
 | `play()`                     | Play                                                                                                                                          |
@@ -27,16 +27,16 @@ It supports the following operations:
 | `activateSoundcheck()`       | Activate soundcheck                                                                                                                           |
 | `deactivateSoundcheck()`     | Deactivate soundcheck                                                                                                                         |
 | `toggleSoundcheck()`         | Toggle soundcheck                                                                                                                             |
-| `setSoundcheck(value)`       | Set soundcheck (activate or deactivate) (`0` or `1`)                                                                                          |
+| `setSoundcheck(value)`       | Set soundcheck (activate or deactivate)                                                                                                       |
 
 To select channels for multi-track recording, the `MasterChannel` itself offers the corresponding interface.
 After getting access to a `MasterChannel` input or line channel (e.g. `conn.master.input(1)`), the following operations are available:
 
-| Call on `MasterChannel` | Description                                             |
-| ----------------------- | ------------------------------------------------------- |
-| `multiTrackSelected$`   | Multitrack selection state for the channel (`0` or `1`) |
-| `multiTrackSelect()`    | Select this channel for multitrack recording            |
-| `multiTrackUnselect()`  | Remove this channel from multitrack recording           |
-| `multiTrackSelect()`    | Toggle multitrack recording for this channel            |
+| Call on `MasterChannel` | Description                                   |
+| ----------------------- | --------------------------------------------- |
+| `multiTrackSelected$`   | Multitrack selection state for the channel    |
+| `multiTrackSelect()`    | Select this channel for multitrack recording  |
+| `multiTrackUnselect()`  | Remove this channel from multitrack recording |
+| `multiTrackSelect()`    | Toggle multitrack recording for this channel  |
 
 Please note that multitrack selections will only apply to single channels. Stereo-linked channels will not be selected automatically.

--- a/packages/mixer-connection/src/lib/__tests__/outbound-messages.spec.ts
+++ b/packages/mixer-connection/src/lib/__tests__/outbound-messages.spec.ts
@@ -50,10 +50,10 @@ describe('Outbound messages', () => {
     conn.master.undim();
     expect(message).toBe('SETD^m.dim^0');
 
-    conn.master.setDim(1);
+    conn.master.setDim(true);
     expect(message).toBe('SETD^m.dim^1');
 
-    conn.master.setDim(0);
+    conn.master.setDim(false);
     expect(message).toBe('SETD^m.dim^0');
 
     conn.master.setDelayL(500);
@@ -76,10 +76,10 @@ describe('Outbound messages', () => {
     conn.master.input(3).setFaderLevelDB(-12);
     expect(message).toBe('SETD^i.2.mix^0.49333689429');
 
-    conn.master.input(3).setMute(1);
+    conn.master.input(3).setMute(true);
     expect(message).toBe('SETD^i.2.mute^1');
 
-    conn.master.input(3).setMute(0);
+    conn.master.input(3).setMute(false);
     expect(message).toBe('SETD^i.2.mute^0');
 
     conn.master.input(3).mute();
@@ -97,10 +97,10 @@ describe('Outbound messages', () => {
     conn.master.input(3).setPan(1.1);
     expect(message).toBe('SETD^i.2.pan^1'); // clamp
 
-    conn.master.input(3).setSolo(0);
+    conn.master.input(3).setSolo(false);
     expect(message).toBe('SETD^i.2.solo^0');
 
-    conn.master.input(3).setSolo(1);
+    conn.master.input(3).setSolo(true);
     expect(message).toBe('SETD^i.2.solo^1');
 
     conn.master.input(3).solo();
@@ -152,10 +152,10 @@ describe('Outbound messages', () => {
     conn.master.line(1).setFaderLevelDB(-12);
     expect(message).toBe('SETD^l.0.mix^0.49333689429');
 
-    conn.master.line(1).setMute(1);
+    conn.master.line(1).setMute(true);
     expect(message).toBe('SETD^l.0.mute^1');
 
-    conn.master.line(1).setMute(0);
+    conn.master.line(1).setMute(false);
     expect(message).toBe('SETD^l.0.mute^0');
 
     conn.master.line(1).mute();
@@ -173,10 +173,10 @@ describe('Outbound messages', () => {
     conn.master.line(1).setPan(3);
     expect(message).toBe('SETD^l.0.pan^1'); // clamp
 
-    conn.master.line(1).setSolo(0);
+    conn.master.line(1).setSolo(false);
     expect(message).toBe('SETD^l.0.solo^0');
 
-    conn.master.line(1).setSolo(1);
+    conn.master.line(1).setSolo(true);
     expect(message).toBe('SETD^l.0.solo^1');
 
     conn.master.line(1).solo();
@@ -205,10 +205,10 @@ describe('Outbound messages', () => {
     conn.master.player(2).setFaderLevelDB(-12);
     expect(message).toBe('SETD^p.1.mix^0.49333689429');
 
-    conn.master.player(2).setMute(1);
+    conn.master.player(2).setMute(true);
     expect(message).toBe('SETD^p.1.mute^1');
 
-    conn.master.player(2).setMute(0);
+    conn.master.player(2).setMute(false);
     expect(message).toBe('SETD^p.1.mute^0');
 
     conn.master.player(2).mute();
@@ -226,10 +226,10 @@ describe('Outbound messages', () => {
     conn.master.player(2).setPan(1.3);
     expect(message).toBe('SETD^p.1.pan^1'); // clamp
 
-    conn.master.player(2).setSolo(0);
+    conn.master.player(2).setSolo(false);
     expect(message).toBe('SETD^p.1.solo^0');
 
-    conn.master.player(2).setSolo(1);
+    conn.master.player(2).setSolo(true);
     expect(message).toBe('SETD^p.1.solo^1');
 
     conn.master.player(2).solo();
@@ -255,10 +255,10 @@ describe('Outbound messages', () => {
     conn.master.aux(1).setFaderLevelDB(-12);
     expect(message).toBe('SETD^a.0.mix^0.49333689429');
 
-    conn.master.aux(1).setMute(1);
+    conn.master.aux(1).setMute(true);
     expect(message).toBe('SETD^a.0.mute^1');
 
-    conn.master.aux(1).setMute(0);
+    conn.master.aux(1).setMute(false);
     expect(message).toBe('SETD^a.0.mute^0');
 
     conn.master.aux(1).mute();
@@ -276,10 +276,10 @@ describe('Outbound messages', () => {
     conn.master.aux(1).setPan(2.2);
     expect(message).toBe('SETD^a.0.pan^1'); // clamp
 
-    conn.master.aux(1).setSolo(0);
+    conn.master.aux(1).setSolo(false);
     expect(message).toBe('SETD^a.0.solo^0');
 
-    conn.master.aux(1).setSolo(1);
+    conn.master.aux(1).setSolo(true);
     expect(message).toBe('SETD^a.0.solo^1');
 
     conn.master.aux(1).solo();
@@ -308,10 +308,10 @@ describe('Outbound messages', () => {
     conn.master.fx(3).setFaderLevelDB(-12);
     expect(message).toBe('SETD^f.2.mix^0.49333689429');
 
-    conn.master.fx(3).setMute(1);
+    conn.master.fx(3).setMute(true);
     expect(message).toBe('SETD^f.2.mute^1');
 
-    conn.master.fx(3).setMute(0);
+    conn.master.fx(3).setMute(false);
     expect(message).toBe('SETD^f.2.mute^0');
 
     conn.master.fx(3).mute();
@@ -329,10 +329,10 @@ describe('Outbound messages', () => {
     conn.master.fx(3).setPan(10);
     expect(message).toBe('SETD^f.2.pan^1'); // clamp
 
-    conn.master.fx(3).setSolo(0);
+    conn.master.fx(3).setSolo(false);
     expect(message).toBe('SETD^f.2.solo^0');
 
-    conn.master.fx(3).setSolo(1);
+    conn.master.fx(3).setSolo(true);
     expect(message).toBe('SETD^f.2.solo^1');
 
     conn.master.fx(3).solo();
@@ -358,10 +358,10 @@ describe('Outbound messages', () => {
     conn.master.sub(4).setFaderLevelDB(-12);
     expect(message).toBe('SETD^s.3.mix^0.49333689429');
 
-    conn.master.sub(4).setMute(1);
+    conn.master.sub(4).setMute(true);
     expect(message).toBe('SETD^s.3.mute^1');
 
-    conn.master.sub(4).setMute(0);
+    conn.master.sub(4).setMute(false);
     expect(message).toBe('SETD^s.3.mute^0');
 
     conn.master.sub(4).mute();
@@ -379,10 +379,10 @@ describe('Outbound messages', () => {
     conn.master.sub(4).setPan(5.4);
     expect(message).toBe('SETD^s.3.pan^1'); // clamp
 
-    conn.master.sub(4).setSolo(0);
+    conn.master.sub(4).setSolo(false);
     expect(message).toBe('SETD^s.3.solo^0');
 
-    conn.master.sub(4).setSolo(1);
+    conn.master.sub(4).setSolo(true);
     expect(message).toBe('SETD^s.3.solo^1');
 
     conn.master.sub(4).solo();
@@ -408,10 +408,10 @@ describe('Outbound messages', () => {
     conn.master.vca(3).setFaderLevelDB(-12);
     expect(message).toBe('SETD^v.2.mix^0.49333689429');
 
-    conn.master.vca(3).setMute(1);
+    conn.master.vca(3).setMute(true);
     expect(message).toBe('SETD^v.2.mute^1');
 
-    conn.master.vca(3).setMute(0);
+    conn.master.vca(3).setMute(false);
     expect(message).toBe('SETD^v.2.mute^0');
 
     conn.master.vca(3).mute();
@@ -429,10 +429,10 @@ describe('Outbound messages', () => {
     conn.master.vca(3).setPan(-0.1);
     expect(message).toBe('SETD^v.2.pan^0'); // clamp
 
-    conn.master.vca(3).setSolo(0);
+    conn.master.vca(3).setSolo(false);
     expect(message).toBe('SETD^v.2.solo^0');
 
-    conn.master.vca(3).setSolo(1);
+    conn.master.vca(3).setSolo(true);
     expect(message).toBe('SETD^v.2.solo^1');
 
     conn.master.vca(3).solo();
@@ -458,10 +458,10 @@ describe('Outbound messages', () => {
     conn.aux(2).input(7).setFaderLevelDB(6);
     expect(message).toBe('SETD^i.6.aux.1.value^0.91653908203');
 
-    conn.aux(2).input(7).setMute(1);
+    conn.aux(2).input(7).setMute(true);
     expect(message).toBe('SETD^i.6.aux.1.mute^1');
 
-    conn.aux(2).input(7).setMute(0);
+    conn.aux(2).input(7).setMute(false);
     expect(message).toBe('SETD^i.6.aux.1.mute^0');
 
     conn.aux(2).input(7).mute();
@@ -485,10 +485,10 @@ describe('Outbound messages', () => {
     conn.aux(2).input(7).post();
     expect(message).toBe('SETD^i.6.aux.1.post^1');
 
-    conn.aux(2).input(7).setPost(1);
+    conn.aux(2).input(7).setPost(true);
     expect(message).toBe('SETD^i.6.aux.1.post^1');
 
-    conn.aux(2).input(7).setPost(0);
+    conn.aux(2).input(7).setPost(false);
     expect(message).toBe('SETD^i.6.aux.1.post^0');
 
     conn.aux(2).input(7).preProc();
@@ -497,10 +497,10 @@ describe('Outbound messages', () => {
     conn.aux(2).input(7).postProc();
     expect(message).toBe('SETD^i.6.aux.1.postproc^1');
 
-    conn.aux(2).input(7).setPostProc(1);
+    conn.aux(2).input(7).setPostProc(true);
     expect(message).toBe('SETD^i.6.aux.1.postproc^1');
 
-    conn.aux(2).input(7).setPostProc(0);
+    conn.aux(2).input(7).setPostProc(false);
     expect(message).toBe('SETD^i.6.aux.1.postproc^0');
 
     conn.aux(2).input(7).setName('THENAME');
@@ -520,10 +520,10 @@ describe('Outbound messages', () => {
     conn.aux(2).line(1).setFaderLevelDB(6);
     expect(message).toBe('SETD^l.0.aux.1.value^0.91653908203');
 
-    conn.aux(2).line(1).setMute(1);
+    conn.aux(2).line(1).setMute(true);
     expect(message).toBe('SETD^l.0.aux.1.mute^1');
 
-    conn.aux(2).line(1).setMute(0);
+    conn.aux(2).line(1).setMute(false);
     expect(message).toBe('SETD^l.0.aux.1.mute^0');
 
     conn.aux(2).line(1).mute();
@@ -547,10 +547,10 @@ describe('Outbound messages', () => {
     conn.aux(2).line(1).post();
     expect(message).toBe('SETD^l.0.aux.1.post^1');
 
-    conn.aux(2).line(1).setPost(1);
+    conn.aux(2).line(1).setPost(true);
     expect(message).toBe('SETD^l.0.aux.1.post^1');
 
-    conn.aux(2).line(1).setPost(0);
+    conn.aux(2).line(1).setPost(false);
     expect(message).toBe('SETD^l.0.aux.1.post^0');
 
     conn.aux(2).line(1).preProc();
@@ -559,10 +559,10 @@ describe('Outbound messages', () => {
     conn.aux(2).line(1).postProc();
     expect(message).toBe('SETD^l.0.aux.1.postproc^1');
 
-    conn.aux(2).line(1).setPostProc(1);
+    conn.aux(2).line(1).setPostProc(true);
     expect(message).toBe('SETD^l.0.aux.1.postproc^1');
 
-    conn.aux(2).line(1).setPostProc(0);
+    conn.aux(2).line(1).setPostProc(false);
     expect(message).toBe('SETD^l.0.aux.1.postproc^0');
 
     conn.aux(2).line(1).setName('THENAME');
@@ -582,10 +582,10 @@ describe('Outbound messages', () => {
     conn.aux(2).player(2).setFaderLevelDB(6);
     expect(message).toBe('SETD^p.1.aux.1.value^0.91653908203');
 
-    conn.aux(2).player(2).setMute(1);
+    conn.aux(2).player(2).setMute(true);
     expect(message).toBe('SETD^p.1.aux.1.mute^1');
 
-    conn.aux(2).player(2).setMute(0);
+    conn.aux(2).player(2).setMute(false);
     expect(message).toBe('SETD^p.1.aux.1.mute^0');
 
     conn.aux(2).player(2).mute();
@@ -609,10 +609,10 @@ describe('Outbound messages', () => {
     conn.aux(2).player(2).post();
     expect(message).toBe('SETD^p.1.aux.1.post^1');
 
-    conn.aux(2).player(2).setPost(1);
+    conn.aux(2).player(2).setPost(true);
     expect(message).toBe('SETD^p.1.aux.1.post^1');
 
-    conn.aux(2).player(2).setPost(0);
+    conn.aux(2).player(2).setPost(false);
     expect(message).toBe('SETD^p.1.aux.1.post^0');
 
     conn.aux(2).player(2).preProc();
@@ -621,10 +621,10 @@ describe('Outbound messages', () => {
     conn.aux(2).player(2).postProc();
     expect(message).toBe('SETD^p.1.aux.1.postproc^1');
 
-    conn.aux(2).player(2).setPostProc(1);
+    conn.aux(2).player(2).setPostProc(true);
     expect(message).toBe('SETD^p.1.aux.1.postproc^1');
 
-    conn.aux(2).player(2).setPostProc(0);
+    conn.aux(2).player(2).setPostProc(false);
     expect(message).toBe('SETD^p.1.aux.1.postproc^0');
 
     conn.aux(2).player(2).setName('THENAME');
@@ -644,10 +644,10 @@ describe('Outbound messages', () => {
     conn.aux(2).fx(1).setFaderLevelDB(6);
     expect(message).toBe('SETD^f.0.aux.1.value^0.91653908203');
 
-    conn.aux(2).fx(1).setMute(1);
+    conn.aux(2).fx(1).setMute(true);
     expect(message).toBe('SETD^f.0.aux.1.mute^1');
 
-    conn.aux(2).fx(1).setMute(0);
+    conn.aux(2).fx(1).setMute(false);
     expect(message).toBe('SETD^f.0.aux.1.mute^0');
 
     conn.aux(2).fx(1).mute();
@@ -671,10 +671,10 @@ describe('Outbound messages', () => {
     conn.aux(2).fx(1).post();
     expect(message).toBe('SETD^f.0.aux.1.post^1');
 
-    conn.aux(2).fx(1).setPost(1);
+    conn.aux(2).fx(1).setPost(true);
     expect(message).toBe('SETD^f.0.aux.1.post^1');
 
-    conn.aux(2).fx(1).setPost(0);
+    conn.aux(2).fx(1).setPost(false);
     expect(message).toBe('SETD^f.0.aux.1.post^0');
 
     conn.aux(2).fx(1).preProc();
@@ -683,10 +683,10 @@ describe('Outbound messages', () => {
     conn.aux(2).fx(1).postProc();
     expect(message).toBe('SETD^f.0.aux.1.postproc^1');
 
-    conn.aux(2).fx(1).setPostProc(1);
+    conn.aux(2).fx(1).setPostProc(true);
     expect(message).toBe('SETD^f.0.aux.1.postproc^1');
 
-    conn.aux(2).fx(1).setPostProc(0);
+    conn.aux(2).fx(1).setPostProc(false);
     expect(message).toBe('SETD^f.0.aux.1.postproc^0');
 
     conn.aux(2).fx(1).setName('THENAME');
@@ -706,10 +706,10 @@ describe('Outbound messages', () => {
     conn.mtx(7).aux(1).setFaderLevelDB(6);
     expect(message).toBe('SETD^a.0.mtx.6.value^0.91653908203');
 
-    conn.mtx(7).aux(1).setMute(1);
+    conn.mtx(7).aux(1).setMute(true);
     expect(message).toBe('SETD^a.0.mtx.6.mute^1');
 
-    conn.mtx(7).aux(1).setMute(0);
+    conn.mtx(7).aux(1).setMute(false);
     expect(message).toBe('SETD^a.0.mtx.6.mute^0');
 
     conn.mtx(7).aux(1).mute();
@@ -733,10 +733,10 @@ describe('Outbound messages', () => {
     conn.mtx(7).aux(1).postProc();
     expect(message).toBe('SETD^a.0.mtx.6.postproc^1');
 
-    conn.mtx(7).aux(1).setPostProc(1);
+    conn.mtx(7).aux(1).setPostProc(true);
     expect(message).toBe('SETD^a.0.mtx.6.postproc^1');
 
-    conn.mtx(7).aux(1).setPostProc(0);
+    conn.mtx(7).aux(1).setPostProc(false);
     expect(message).toBe('SETD^a.0.mtx.6.postproc^0');
 
     conn.mtx(7).aux(1).setName('THENAME');
@@ -756,10 +756,10 @@ describe('Outbound messages', () => {
     conn.mtx(7).sub(1).setFaderLevelDB(6);
     expect(message).toBe('SETD^s.0.mtx.6.value^0.91653908203');
 
-    conn.mtx(7).sub(1).setMute(1);
+    conn.mtx(7).sub(1).setMute(true);
     expect(message).toBe('SETD^s.0.mtx.6.mute^1');
 
-    conn.mtx(7).sub(1).setMute(0);
+    conn.mtx(7).sub(1).setMute(false);
     expect(message).toBe('SETD^s.0.mtx.6.mute^0');
 
     conn.mtx(7).sub(1).mute();
@@ -783,10 +783,10 @@ describe('Outbound messages', () => {
     conn.mtx(7).sub(1).postProc();
     expect(message).toBe('SETD^s.0.mtx.6.postproc^1');
 
-    conn.mtx(7).sub(1).setPostProc(1);
+    conn.mtx(7).sub(1).setPostProc(true);
     expect(message).toBe('SETD^s.0.mtx.6.postproc^1');
 
-    conn.mtx(7).sub(1).setPostProc(0);
+    conn.mtx(7).sub(1).setPostProc(false);
     expect(message).toBe('SETD^s.0.mtx.6.postproc^0');
 
     conn.mtx(7).sub(1).setName('THENAME');
@@ -806,10 +806,10 @@ describe('Outbound messages', () => {
     conn.mtx(7).master().setFaderLevelDB(6);
     expect(message).toBe('SETD^m.mtx.6.value^0.91653908203');
 
-    conn.mtx(7).master().setMute(1);
+    conn.mtx(7).master().setMute(true);
     expect(message).toBe('SETD^m.mtx.6.mute^1');
 
-    conn.mtx(7).master().setMute(0);
+    conn.mtx(7).master().setMute(false);
     expect(message).toBe('SETD^m.mtx.6.mute^0');
 
     conn.mtx(7).master().mute();
@@ -833,10 +833,10 @@ describe('Outbound messages', () => {
     conn.mtx(7).master().postProc();
     expect(message).toBe('SETD^m.mtx.6.postproc^1');
 
-    conn.mtx(7).master().setPostProc(1);
+    conn.mtx(7).master().setPostProc(true);
     expect(message).toBe('SETD^m.mtx.6.postproc^1');
 
-    conn.mtx(7).master().setPostProc(0);
+    conn.mtx(7).master().setPostProc(false);
     expect(message).toBe('SETD^m.mtx.6.postproc^0');
   });
 
@@ -844,10 +844,10 @@ describe('Outbound messages', () => {
     conn.master.mtx(7).setFaderLevel(0.4);
     expect(message).toBe('SETD^a.6.mix^0.4');
 
-    conn.master.mtx(7).setMute(1);
+    conn.master.mtx(7).setMute(true);
     expect(message).toBe('SETD^a.6.mute^1');
 
-    conn.master.mtx(7).setSolo(1);
+    conn.master.mtx(7).setSolo(true);
     expect(message).toBe('SETD^a.6.solo^1');
 
     conn.master.mtx(7).setDelay(400);
@@ -881,10 +881,10 @@ describe('Outbound messages', () => {
     conn.fx(3).input(6).setFaderLevelDB(9.4);
     expect(message).toBe('SETD^i.5.fx.2.value^0.98845064599');
 
-    conn.fx(3).input(6).setMute(1);
+    conn.fx(3).input(6).setMute(true);
     expect(message).toBe('SETD^i.5.fx.2.mute^1');
 
-    conn.fx(3).input(6).setMute(0);
+    conn.fx(3).input(6).setMute(false);
     expect(message).toBe('SETD^i.5.fx.2.mute^0');
 
     conn.fx(3).input(6).mute();
@@ -899,10 +899,10 @@ describe('Outbound messages', () => {
     conn.fx(3).input(6).post();
     expect(message).toBe('SETD^i.5.fx.2.post^1');
 
-    conn.fx(3).input(6).setPost(1);
+    conn.fx(3).input(6).setPost(true);
     expect(message).toBe('SETD^i.5.fx.2.post^1');
 
-    conn.fx(3).input(6).setPost(0);
+    conn.fx(3).input(6).setPost(false);
     expect(message).toBe('SETD^i.5.fx.2.post^0');
 
     conn.fx(3).input(6).setName('THENAME');
@@ -922,10 +922,10 @@ describe('Outbound messages', () => {
     conn.fx(3).line(2).setFaderLevelDB(9.4);
     expect(message).toBe('SETD^l.1.fx.2.value^0.98845064599');
 
-    conn.fx(3).line(2).setMute(1);
+    conn.fx(3).line(2).setMute(true);
     expect(message).toBe('SETD^l.1.fx.2.mute^1');
 
-    conn.fx(3).line(2).setMute(0);
+    conn.fx(3).line(2).setMute(false);
     expect(message).toBe('SETD^l.1.fx.2.mute^0');
 
     conn.fx(3).line(2).mute();
@@ -940,10 +940,10 @@ describe('Outbound messages', () => {
     conn.fx(3).line(2).post();
     expect(message).toBe('SETD^l.1.fx.2.post^1');
 
-    conn.fx(3).line(2).setPost(1);
+    conn.fx(3).line(2).setPost(true);
     expect(message).toBe('SETD^l.1.fx.2.post^1');
 
-    conn.fx(3).line(2).setPost(0);
+    conn.fx(3).line(2).setPost(false);
     expect(message).toBe('SETD^l.1.fx.2.post^0');
 
     conn.fx(3).line(2).setName('THENAME');
@@ -963,10 +963,10 @@ describe('Outbound messages', () => {
     conn.fx(3).player(1).setFaderLevelDB(9.4);
     expect(message).toBe('SETD^p.0.fx.2.value^0.98845064599');
 
-    conn.fx(3).player(1).setMute(1);
+    conn.fx(3).player(1).setMute(true);
     expect(message).toBe('SETD^p.0.fx.2.mute^1');
 
-    conn.fx(3).player(1).setMute(0);
+    conn.fx(3).player(1).setMute(false);
     expect(message).toBe('SETD^p.0.fx.2.mute^0');
 
     conn.fx(3).player(1).mute();
@@ -981,10 +981,10 @@ describe('Outbound messages', () => {
     conn.fx(3).player(1).post();
     expect(message).toBe('SETD^p.0.fx.2.post^1');
 
-    conn.fx(3).player(1).setPost(1);
+    conn.fx(3).player(1).setPost(true);
     expect(message).toBe('SETD^p.0.fx.2.post^1');
 
-    conn.fx(3).player(1).setPost(0);
+    conn.fx(3).player(1).setPost(false);
     expect(message).toBe('SETD^p.0.fx.2.post^0');
 
     conn.fx(3).player(1).setName('THENAME');
@@ -1004,10 +1004,10 @@ describe('Outbound messages', () => {
     conn.fx(3).sub(4).setFaderLevelDB(9.4);
     expect(message).toBe('SETD^s.3.fx.2.value^0.98845064599');
 
-    conn.fx(3).sub(4).setMute(1);
+    conn.fx(3).sub(4).setMute(true);
     expect(message).toBe('SETD^s.3.fx.2.mute^1');
 
-    conn.fx(3).sub(4).setMute(0);
+    conn.fx(3).sub(4).setMute(false);
     expect(message).toBe('SETD^s.3.fx.2.mute^0');
 
     conn.fx(3).sub(4).mute();
@@ -1022,10 +1022,10 @@ describe('Outbound messages', () => {
     conn.fx(3).sub(4).post();
     expect(message).toBe('SETD^s.3.fx.2.post^1');
 
-    conn.fx(3).sub(4).setPost(1);
+    conn.fx(3).sub(4).setPost(true);
     expect(message).toBe('SETD^s.3.fx.2.post^1');
 
-    conn.fx(3).sub(4).setPost(0);
+    conn.fx(3).sub(4).setPost(false);
     expect(message).toBe('SETD^s.3.fx.2.post^0');
 
     conn.fx(3).sub(4).setName('THENAME');
@@ -1085,10 +1085,10 @@ describe('Outbound messages', () => {
     conn.player.loadTrack('~root~', 'mytrack.mp3');
     expect(message).toBe('MEDIA_SWITCH_TRACK^~root~^mytrack.mp3');
 
-    conn.player.setShuffle(1);
+    conn.player.setShuffle(true);
     expect(message).toBe('SETD^settings.shuffle^1');
 
-    conn.player.setShuffle(0);
+    conn.player.setShuffle(false);
     expect(message).toBe('SETD^settings.shuffle^0');
 
     conn.player.setPlayMode(0);
@@ -1124,10 +1124,10 @@ describe('Outbound messages', () => {
     mtk.recordToggle();
     expect(message).toBe('MTK_REC_TOGGLE');
 
-    mtk.setSoundcheck(0);
+    mtk.setSoundcheck(false);
     expect(message).toBe('SETD^var.mtk.soundcheck^0');
 
-    mtk.setSoundcheck(1);
+    mtk.setSoundcheck(true);
     expect(message).toBe('SETD^var.mtk.soundcheck^1');
 
     mtk.deactivateSoundcheck();
@@ -1228,10 +1228,10 @@ describe('Outbound messages', () => {
     it('Ui24', () => {
       setMixerModel('ui24', conn);
 
-      conn.hw(1).setPhantom(1);
+      conn.hw(1).setPhantom(true);
       expect(message).toBe('SETD^hw.0.phantom^1');
 
-      conn.hw(2).setPhantom(0);
+      conn.hw(2).setPhantom(false);
       expect(message).toBe('SETD^hw.1.phantom^0');
 
       conn.hw(3).phantomOn();
@@ -1259,10 +1259,10 @@ describe('Outbound messages', () => {
     it('Ui16', () => {
       setMixerModel('ui16', conn);
 
-      conn.hw(1).setPhantom(1);
+      conn.hw(1).setPhantom(true);
       expect(message).toBe('SETD^i.0.phantom^1');
 
-      conn.hw(2).setPhantom(0);
+      conn.hw(2).setPhantom(false);
       expect(message).toBe('SETD^i.1.phantom^0');
 
       conn.hw(3).phantomOn();
@@ -1290,10 +1290,10 @@ describe('Outbound messages', () => {
     it('Ui12', () => {
       setMixerModel('ui12', conn);
 
-      conn.hw(1).setPhantom(1);
+      conn.hw(1).setPhantom(true);
       expect(message).toBe('SETD^i.0.phantom^1');
 
-      conn.hw(2).setPhantom(0);
+      conn.hw(2).setPhantom(false);
       expect(message).toBe('SETD^i.1.phantom^0');
 
       conn.hw(3).phantomOn();

--- a/packages/mixer-connection/src/lib/facade/automix-controller.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/automix-controller.spec.ts
@@ -96,51 +96,51 @@ describe('Automix Controller', () => {
     it('state$', async () => {
       // A
       conn.conn.sendMessage('SETD^automix.a.on^1');
-      expect(await firstValueFrom(groupA.state$)).toBe(1);
+      expect(await firstValueFrom(groupA.state$)).toBe(true);
 
       conn.conn.sendMessage('SETD^automix.b.on^1');
-      expect(await firstValueFrom(groupB.state$)).toBe(1);
+      expect(await firstValueFrom(groupB.state$)).toBe(true);
 
       // B
       conn.conn.sendMessage('SETD^automix.a.on^0');
-      expect(await firstValueFrom(groupA.state$)).toBe(0);
+      expect(await firstValueFrom(groupA.state$)).toBe(false);
 
       conn.conn.sendMessage('SETD^automix.b.on^0');
-      expect(await firstValueFrom(groupB.state$)).toBe(0);
+      expect(await firstValueFrom(groupB.state$)).toBe(false);
     });
 
     it('enable/disable', async () => {
       // A
       groupA.enable();
-      expect(await firstValueFrom(groupA.state$)).toBe(1);
+      expect(await firstValueFrom(groupA.state$)).toBe(true);
 
       groupA.disable();
-      expect(await firstValueFrom(groupA.state$)).toBe(0);
+      expect(await firstValueFrom(groupA.state$)).toBe(false);
 
       // B
       groupB.enable();
-      expect(await firstValueFrom(groupB.state$)).toBe(1);
+      expect(await firstValueFrom(groupB.state$)).toBe(true);
 
       groupB.disable();
-      expect(await firstValueFrom(groupB.state$)).toBe(0);
+      expect(await firstValueFrom(groupB.state$)).toBe(false);
     });
 
     it('toggle', async () => {
       // A
       groupA.enable();
       groupA.toggle();
-      expect(await firstValueFrom(groupA.state$)).toBe(0);
+      expect(await firstValueFrom(groupA.state$)).toBe(false);
 
       groupA.toggle();
-      expect(await firstValueFrom(groupA.state$)).toBe(1);
+      expect(await firstValueFrom(groupA.state$)).toBe(true);
 
       // B
       groupA.disable();
       groupA.toggle();
-      expect(await firstValueFrom(groupA.state$)).toBe(1);
+      expect(await firstValueFrom(groupA.state$)).toBe(true);
 
       groupA.toggle();
-      expect(await firstValueFrom(groupA.state$)).toBe(0);
+      expect(await firstValueFrom(groupA.state$)).toBe(false);
     });
   });
 });

--- a/packages/mixer-connection/src/lib/facade/automix-controller.ts
+++ b/packages/mixer-connection/src/lib/facade/automix-controller.ts
@@ -1,14 +1,14 @@
 import { map, take } from 'rxjs';
 import { MixerConnection } from '../mixer-connection';
 import { MixerStore } from '../state/mixer-store';
-import { selectRawValue } from '../state/state-selectors';
+import { selectBoolean, selectRawValue } from '../state/state-selectors';
 import { faderValueToTimeMs, timeMsToFaderValue } from '../utils/value-converters/value-converters';
 
 export type AutomixGroupId = 'a' | 'b';
 
 export class AutomixGroup {
-  /** Active state of this automix group (`0` or `1`) */
-  readonly state$ = this.store.state$.pipe(selectRawValue<number>(`automix.${this.group}.on`));
+  /** Active state of this automix group */
+  readonly state$ = this.store.state$.pipe(selectBoolean(`automix.${this.group}.on`));
 
   constructor(
     private conn: MixerConnection,
@@ -16,23 +16,23 @@ export class AutomixGroup {
     private group: AutomixGroupId,
   ) {}
 
-  private setState(value: number) {
-    this.conn.setd(`automix.${this.group}.on`, value);
+  private setState(value: boolean) {
+    this.conn.setdBool(`automix.${this.group}.on`, value);
   }
 
   /** Enable this automix group */
   enable() {
-    this.setState(1);
+    this.setState(true);
   }
 
   /** Disable this automix group */
   disable() {
-    this.setState(0);
+    this.setState(false);
   }
 
   /** Toggle the state of this automix group */
   toggle() {
-    this.state$.pipe(take(1)).subscribe(value => this.setState(value ^ 1));
+    this.state$.pipe(take(1)).subscribe(value => this.setState(!value));
   }
 }
 

--- a/packages/mixer-connection/src/lib/facade/aux-bus.ts
+++ b/packages/mixer-connection/src/lib/facade/aux-bus.ts
@@ -1,5 +1,3 @@
-import { map } from 'rxjs';
-
 import { MixerConnection } from '../mixer-connection';
 import { MixerStore } from '../state/mixer-store';
 import { select, selectMatrix } from '../state/state-selectors';
@@ -16,7 +14,7 @@ export class AuxBus {
    * Whether this AUX bus is currently configured as a matrix bus (Ui24R only).
    * When `true`, this slot is a matrix and should be controlled through `conn.mtx(n)` instead.
    */
-  readonly isMatrix$ = this.store.state$.pipe(select(selectMatrix(this.bus)), map(Boolean));
+  readonly isMatrix$ = this.store.state$.pipe(select(selectMatrix(this.bus)));
 
   constructor(
     private conn: MixerConnection,
@@ -74,7 +72,7 @@ export class AuxBus {
    * @returns the matrix bus (`MtxBus`) for the same slot
    */
   switchToMatrix(): MtxBus {
-    setMatrixMode(this.conn, this.store, this.bus, 1);
+    setMatrixMode(this.conn, this.store, this.bus, true);
     return this.store.objectStore.getOrCreate(
       mtxBusStoreId(this.bus),
       () => new MtxBus(this.conn, this.store, this.bus),

--- a/packages/mixer-connection/src/lib/facade/aux-channel.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/aux-channel.spec.ts
@@ -51,35 +51,35 @@ describe('AUX Channel', () => {
   describe('PRE/POST', () => {
     it('post$', async () => {
       channel.post();
-      expect(await firstValueFrom(channel.post$)).toBe(1);
+      expect(await firstValueFrom(channel.post$)).toBe(true);
 
       channel.pre();
-      expect(await firstValueFrom(channel.post$)).toBe(0);
+      expect(await firstValueFrom(channel.post$)).toBe(false);
 
-      channel.setPost(1);
-      expect(await firstValueFrom(channel.post$)).toBe(1);
+      channel.setPost(true);
+      expect(await firstValueFrom(channel.post$)).toBe(true);
     });
 
     it('togglePost', async () => {
-      channel.setPost(0);
+      channel.setPost(false);
       channel.togglePost();
-      expect(await firstValueFrom(channel.post$)).toBe(1);
+      expect(await firstValueFrom(channel.post$)).toBe(true);
 
       channel.togglePost();
-      expect(await firstValueFrom(channel.post$)).toBe(0);
+      expect(await firstValueFrom(channel.post$)).toBe(false);
     });
   });
 
   describe('PRE/POST PROC', () => {
     it('postProc$', async () => {
       channel.postProc();
-      expect(await firstValueFrom(channel.postProc$)).toBe(1);
+      expect(await firstValueFrom(channel.postProc$)).toBe(true);
 
       channel.preProc();
-      expect(await firstValueFrom(channel.postProc$)).toBe(0);
+      expect(await firstValueFrom(channel.postProc$)).toBe(false);
 
-      channel.setPostProc(1);
-      expect(await firstValueFrom(channel.postProc$)).toBe(1);
+      channel.setPostProc(true);
+      expect(await firstValueFrom(channel.postProc$)).toBe(true);
     });
   });
 });

--- a/packages/mixer-connection/src/lib/facade/aux-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/aux-channel.ts
@@ -20,7 +20,7 @@ export class AuxChannel extends SendChannel implements PannableChannel, PostProc
     select(selectPan(this.channelType, this.channel, this.busType, this.bus)),
   );
 
-  /** PRE/POST PROC value of the AUX channel (`1` (POST PROC) or `0` (PRE PROC)) */
+  /** PRE/POST PROC state of the AUX channel (`false` for PRE PROC, `true` for POST PROC) */
   readonly postProc$ = this.store.state$.pipe(
     select(selectPostProc(this.channelType, this.channel, this.busType, this.bus)),
   );
@@ -99,22 +99,22 @@ export class AuxChannel extends SendChannel implements PannableChannel, PostProc
   }
 
   /**
-   * Set PRE/POST PROC value for the AUX channel
-   * @param value `1` (POST PROC) or `0` (PRE PROC)
+   * Set PRE/POST PROC state for the AUX channel
+   * @param value POST PROC (`true`) or PRE PROC (`false`)
    */
-  setPostProc(value: number) {
+  setPostProc(value: boolean) {
     [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
-      this.conn.setd(`${cid}.postproc`, value);
+      this.conn.setdBool(`${cid}.postproc`, value);
     });
   }
 
   /** Set AUX channel to POST PROC */
   postProc() {
-    this.setPostProc(1);
+    this.setPostProc(true);
   }
 
   /** Set AUX channel to PRE PROC */
   preProc() {
-    this.setPostProc(0);
+    this.setPostProc(false);
   }
 }

--- a/packages/mixer-connection/src/lib/facade/channel.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/channel.spec.ts
@@ -92,22 +92,22 @@ describe('Channel', () => {
   describe('MUTE', () => {
     it('mute$', async () => {
       channel.mute();
-      expect(await firstValueFrom(channel.mute$)).toBe(1);
+      expect(await firstValueFrom(channel.mute$)).toBe(true);
 
       channel.unmute();
-      expect(await firstValueFrom(channel.mute$)).toBe(0);
+      expect(await firstValueFrom(channel.mute$)).toBe(false);
 
-      channel.setMute(1);
-      expect(await firstValueFrom(channel.mute$)).toBe(1);
+      channel.setMute(true);
+      expect(await firstValueFrom(channel.mute$)).toBe(true);
     });
 
     it('toggleMute', async () => {
-      channel.setMute(0);
+      channel.setMute(false);
       channel.toggleMute();
-      expect(await firstValueFrom(channel.mute$)).toBe(1);
+      expect(await firstValueFrom(channel.mute$)).toBe(true);
 
       channel.toggleMute();
-      expect(await firstValueFrom(channel.mute$)).toBe(0);
+      expect(await firstValueFrom(channel.mute$)).toBe(false);
     });
   });
 

--- a/packages/mixer-connection/src/lib/facade/channel.ts
+++ b/packages/mixer-connection/src/lib/facade/channel.ts
@@ -48,7 +48,7 @@ export class Channel implements FadeableChannel {
   /** dB level of the channel (between `-Infinity` and `10`) */
   readonly faderLevelDB$ = this.faderLevel$.pipe(map(v => faderValueToDB(v)));
 
-  /** MUTE value of the channel (`0` or `1`) */
+  /** MUTE state of the channel */
   readonly mute$ = this.store.state$.pipe(
     select(selectMute(this.channelType, this.channel, this.busType, this.bus)),
   );
@@ -167,28 +167,28 @@ export class Channel implements FadeableChannel {
   }
 
   /**
-   * Set MUTE value for the channel
-   * @param value MUTE value `0` or `1`
+   * Set MUTE state for the channel
+   * @param value MUTE state
    */
-  setMute(value: number) {
+  setMute(value: boolean) {
     [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
-      this.conn.setd(`${cid}.mute`, value);
+      this.conn.setdBool(`${cid}.mute`, value);
     });
   }
 
   /** Enable MUTE for the channel */
   mute() {
-    this.setMute(1);
+    this.setMute(true);
   }
 
   /** Disable MUTE for the channel */
   unmute() {
-    this.setMute(0);
+    this.setMute(false);
   }
 
-  /** Toggle MUTE status for the channel */
+  /** Toggle MUTE state for the channel */
   toggleMute() {
-    this.mute$.pipe(take(1)).subscribe(mute => this.setMute(mute ^ 1));
+    this.mute$.pipe(take(1)).subscribe(mute => this.setMute(!mute));
   }
 
   /** Set name of the channel */

--- a/packages/mixer-connection/src/lib/facade/dual-track-recorder.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/dual-track-recorder.spec.ts
@@ -14,18 +14,18 @@ describe('DualTrackRecorder', () => {
 
   it('recording$', async () => {
     conn.conn.sendMessage('SETD^var.isRecording^1');
-    expect(await firstValueFrom(recorder.recording$)).toBe(1);
+    expect(await firstValueFrom(recorder.recording$)).toBe(true);
 
     conn.conn.sendMessage('SETD^var.isRecording^0');
-    expect(await firstValueFrom(recorder.recording$)).toBe(0);
+    expect(await firstValueFrom(recorder.recording$)).toBe(false);
   });
 
   it('busy$', async () => {
     conn.conn.sendMessage('SETD^var.recBusy^1');
-    expect(await firstValueFrom(recorder.busy$)).toBe(1);
+    expect(await firstValueFrom(recorder.busy$)).toBe(true);
 
     conn.conn.sendMessage('SETD^var.recBusy^0');
-    expect(await firstValueFrom(recorder.busy$)).toBe(0);
+    expect(await firstValueFrom(recorder.busy$)).toBe(false);
   });
 
   describe('Recording Start/Stop', () => {

--- a/packages/mixer-connection/src/lib/facade/dual-track-recorder.ts
+++ b/packages/mixer-connection/src/lib/facade/dual-track-recorder.ts
@@ -1,17 +1,17 @@
 import { take } from 'rxjs';
 import { MixerConnection } from '../mixer-connection';
 import { MixerStore } from '../state/mixer-store';
-import { selectRawValue } from '../state/state-selectors';
+import { selectBoolean } from '../state/state-selectors';
 
 /**
  * Represents the 2-track recorder in the media player
  */
 export class DualTrackRecorder {
-  /** Recording state (`0` or `1`) */
-  readonly recording$ = this.store.state$.pipe(selectRawValue('var.isRecording', 0));
+  /** Recording state */
+  readonly recording$ = this.store.state$.pipe(selectBoolean('var.isRecording'));
 
-  /** Recording busy state (`0` or `1`) */
-  readonly busy$ = this.store.state$.pipe(selectRawValue('var.recBusy', 0));
+  /** Recording busy state */
+  readonly busy$ = this.store.state$.pipe(selectBoolean('var.recBusy'));
 
   constructor(
     private conn: MixerConnection,

--- a/packages/mixer-connection/src/lib/facade/fx-channel.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/fx-channel.spec.ts
@@ -81,44 +81,44 @@ describe('FX Channel', () => {
   describe('PRE/POST', () => {
     it('post$', async () => {
       channel.post();
-      expect(await firstValueFrom(channel.post$)).toBe(1);
+      expect(await firstValueFrom(channel.post$)).toBe(true);
 
       channel.pre();
-      expect(await firstValueFrom(channel.post$)).toBe(0);
+      expect(await firstValueFrom(channel.post$)).toBe(false);
 
-      channel.setPost(1);
-      expect(await firstValueFrom(channel.post$)).toBe(1);
+      channel.setPost(true);
+      expect(await firstValueFrom(channel.post$)).toBe(true);
     });
 
     it('togglePost', async () => {
-      channel.setPost(0);
+      channel.setPost(false);
       channel.togglePost();
-      expect(await firstValueFrom(channel.post$)).toBe(1);
+      expect(await firstValueFrom(channel.post$)).toBe(true);
 
       channel.togglePost();
-      expect(await firstValueFrom(channel.post$)).toBe(0);
+      expect(await firstValueFrom(channel.post$)).toBe(false);
     });
   });
 
   describe('MUTE', () => {
     it('mute$', async () => {
       channel.mute();
-      expect(await firstValueFrom(channel.mute$)).toBe(1);
+      expect(await firstValueFrom(channel.mute$)).toBe(true);
 
       channel.unmute();
-      expect(await firstValueFrom(channel.mute$)).toBe(0);
+      expect(await firstValueFrom(channel.mute$)).toBe(false);
 
-      channel.setMute(1);
-      expect(await firstValueFrom(channel.mute$)).toBe(1);
+      channel.setMute(true);
+      expect(await firstValueFrom(channel.mute$)).toBe(true);
     });
 
     it('toggleMute', async () => {
-      channel.setMute(0);
+      channel.setMute(false);
       channel.toggleMute();
-      expect(await firstValueFrom(channel.mute$)).toBe(1);
+      expect(await firstValueFrom(channel.mute$)).toBe(true);
 
       channel.toggleMute();
-      expect(await firstValueFrom(channel.mute$)).toBe(0);
+      expect(await firstValueFrom(channel.mute$)).toBe(false);
     });
   });
 });

--- a/packages/mixer-connection/src/lib/facade/hw-channel.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/hw-channel.spec.ts
@@ -41,48 +41,48 @@ describe('AUX Channel', () => {
 
     it('phantom$', async () => {
       channel.phantomOn();
-      expect(await firstValueFrom(channel.phantom$)).toBe(1);
+      expect(await firstValueFrom(channel.phantom$)).toBe(true);
 
       channel.phantomOff();
-      expect(await firstValueFrom(channel.phantom$)).toBe(0);
+      expect(await firstValueFrom(channel.phantom$)).toBe(false);
 
-      channel.setPhantom(1);
-      expect(await firstValueFrom(channel.phantom$)).toBe(1);
+      channel.setPhantom(true);
+      expect(await firstValueFrom(channel.phantom$)).toBe(true);
     });
 
     it('togglePhantom', async () => {
-      channel.setPhantom(0);
+      channel.setPhantom(false);
       channel.togglePhantom();
-      expect(await firstValueFrom(channel.phantom$)).toBe(1);
+      expect(await firstValueFrom(channel.phantom$)).toBe(true);
 
       channel.togglePhantom();
-      expect(await firstValueFrom(channel.phantom$)).toBe(0);
+      expect(await firstValueFrom(channel.phantom$)).toBe(false);
     });
 
     it('phantom Ui24', async () => {
       setMixerModel('ui24', conn);
 
       conn.conn.sendMessage('SETD^hw.2.phantom^0');
-      expect(await firstValueFrom(channel.phantom$)).toBe(0);
+      expect(await firstValueFrom(channel.phantom$)).toBe(false);
 
       conn.conn.sendMessage('SETD^hw.2.phantom^1');
-      expect(await firstValueFrom(channel.phantom$)).toBe(1);
+      expect(await firstValueFrom(channel.phantom$)).toBe(true);
 
       channel.togglePhantom();
-      expect(await firstValueFrom(channel.phantom$)).toBe(0);
+      expect(await firstValueFrom(channel.phantom$)).toBe(false);
     });
 
     it('phantom Ui12/Ui16', async () => {
       setMixerModel('ui16', conn);
 
       conn.conn.sendMessage('SETD^i.2.phantom^0');
-      expect(await firstValueFrom(channel.phantom$)).toBe(0);
+      expect(await firstValueFrom(channel.phantom$)).toBe(false);
 
       conn.conn.sendMessage('SETD^i.2.phantom^1');
-      expect(await firstValueFrom(channel.phantom$)).toBe(1);
+      expect(await firstValueFrom(channel.phantom$)).toBe(true);
 
       channel.togglePhantom();
-      expect(await firstValueFrom(channel.phantom$)).toBe(0);
+      expect(await firstValueFrom(channel.phantom$)).toBe(false);
     });
   });
 

--- a/packages/mixer-connection/src/lib/facade/hw-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/hw-channel.ts
@@ -15,7 +15,7 @@ import { DeviceInfo } from './device-info';
 export class HwChannel {
   protected fullChannelId = `hw.${this.channel - 1}`;
 
-  /** Phantom power state of the channel (`0` or `1`) */
+  /** Phantom power state of the channel */
   readonly phantom$ = this.deviceInfo.model$.pipe(
     switchMap(model => {
       switch (model) {
@@ -78,25 +78,25 @@ export class HwChannel {
 
   /**
    * Set phantom power state for the channel
-   * @param value `0` or `1`
+   * @param value phantom power state
    */
-  setPhantom(value: number) {
-    this.conn.setd(`${this.fullChannelId}.phantom`, value);
+  setPhantom(value: boolean) {
+    this.conn.setdBool(`${this.fullChannelId}.phantom`, value);
   }
 
   /** Switch ON phantom power for the channel */
   phantomOn() {
-    this.setPhantom(1);
+    this.setPhantom(true);
   }
 
   /** Switch OFF phantom power for the channel */
   phantomOff() {
-    this.setPhantom(0);
+    this.setPhantom(false);
   }
 
   /** Toggle phantom power for the channel */
   togglePhantom() {
-    this.phantom$.pipe(take(1)).subscribe(phantomOn => this.setPhantom(phantomOn ^ 1));
+    this.phantom$.pipe(take(1)).subscribe(phantomOn => this.setPhantom(!phantomOn));
   }
 
   /**

--- a/packages/mixer-connection/src/lib/facade/interfaces.ts
+++ b/packages/mixer-connection/src/lib/facade/interfaces.ts
@@ -27,10 +27,10 @@ export interface PannableChannel {
 }
 
 export interface PostProcessableChannel {
-  /** PRE/POST PROC value of the channel (`1` (POST PROC) or `0` (PRE PROC)) */
-  readonly postProc$: Observable<number>;
+  /** PRE/POST PROC state of the channel (`false` for PRE PROC, `true` for POST PROC) */
+  readonly postProc$: Observable<boolean>;
 
-  setPostProc(value: number): void;
+  setPostProc(value: boolean): void;
   postProc(): void;
   preProc(): void;
 }

--- a/packages/mixer-connection/src/lib/facade/master-bus.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/master-bus.spec.ts
@@ -15,22 +15,22 @@ describe('Master Bus', () => {
   describe('DIM', () => {
     it('dim$', async () => {
       master.dim();
-      expect(await firstValueFrom(master.dim$)).toBe(1);
+      expect(await firstValueFrom(master.dim$)).toBe(true);
 
       master.undim();
-      expect(await firstValueFrom(master.dim$)).toBe(0);
+      expect(await firstValueFrom(master.dim$)).toBe(false);
 
-      master.setDim(1);
-      expect(await firstValueFrom(master.dim$)).toBe(1);
+      master.setDim(true);
+      expect(await firstValueFrom(master.dim$)).toBe(true);
     });
 
     it('toggleDim', async () => {
-      master.setDim(0);
+      master.setDim(false);
       master.toggleDim();
-      expect(await firstValueFrom(master.dim$)).toBe(1);
+      expect(await firstValueFrom(master.dim$)).toBe(true);
 
       master.toggleDim();
-      expect(await firstValueFrom(master.dim$)).toBe(0);
+      expect(await firstValueFrom(master.dim$)).toBe(false);
     });
   });
 

--- a/packages/mixer-connection/src/lib/facade/master-bus.ts
+++ b/packages/mixer-connection/src/lib/facade/master-bus.ts
@@ -34,7 +34,7 @@ export class MasterBus implements FadeableChannel, PannableChannel {
   /** PAN value of the master (between `0` and `1`) */
   readonly pan$ = this.store.state$.pipe(select(selectMasterPan()));
 
-  /** DIM value of the master (`0` or `1`) */
+  /** DIM state of the master */
   readonly dim$ = this.store.state$.pipe(select(selectMasterDim()));
 
   /** LEFT DELAY (ms) of the master */
@@ -236,26 +236,26 @@ export class MasterBus implements FadeableChannel, PannableChannel {
   }
 
   /**
-   * Set DIM value for the master
-   * @param value DIM value `0` or `1`
+   * Set DIM state for the master
+   * @param value DIM state
    */
-  setDim(value: number) {
-    this.conn.setd('m.dim', value);
+  setDim(value: boolean) {
+    this.conn.setdBool('m.dim', value);
   }
 
   /** Enable DIM on the master */
   dim() {
-    this.setDim(1);
+    this.setDim(true);
   }
 
   /** Disable DIM on the master */
   undim() {
-    this.setDim(0);
+    this.setDim(false);
   }
 
   /** Toggle DIM on the master */
   toggleDim() {
-    this.dim$.pipe(take(1)).subscribe(dim => this.setDim(dim ^ 1));
+    this.dim$.pipe(take(1)).subscribe(dim => this.setDim(!dim));
   }
 
   /** Set LEFT DELAY (ms) for master output. Maximum 500 ms */

--- a/packages/mixer-connection/src/lib/facade/master-channel.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/master-channel.spec.ts
@@ -51,22 +51,22 @@ describe('Master Channel', () => {
   describe('SOLO', () => {
     it('solo$', async () => {
       channel.solo();
-      expect(await firstValueFrom(channel.solo$)).toBe(1);
+      expect(await firstValueFrom(channel.solo$)).toBe(true);
 
       channel.unsolo();
-      expect(await firstValueFrom(channel.solo$)).toBe(0);
+      expect(await firstValueFrom(channel.solo$)).toBe(false);
 
-      channel.setSolo(1);
-      expect(await firstValueFrom(channel.solo$)).toBe(1);
+      channel.setSolo(true);
+      expect(await firstValueFrom(channel.solo$)).toBe(true);
     });
 
     it('toggleSolo', async () => {
-      channel.setSolo(0);
+      channel.setSolo(false);
       channel.toggleSolo();
-      expect(await firstValueFrom(channel.solo$)).toBe(1);
+      expect(await firstValueFrom(channel.solo$)).toBe(true);
 
       channel.toggleSolo();
-      expect(await firstValueFrom(channel.solo$)).toBe(0);
+      expect(await firstValueFrom(channel.solo$)).toBe(false);
     });
   });
 
@@ -140,21 +140,21 @@ describe('Master Channel', () => {
   describe('Multitrack Config', () => {
     it('select', async () => {
       channel.multiTrackSelect();
-      expect(await firstValueFrom(channel.multiTrackSelected$)).toBe(1);
+      expect(await firstValueFrom(channel.multiTrackSelected$)).toBe(true);
     });
 
     it('unselect', async () => {
       channel.multiTrackUnselect();
-      expect(await firstValueFrom(channel.multiTrackSelected$)).toBe(0);
+      expect(await firstValueFrom(channel.multiTrackSelected$)).toBe(false);
     });
 
     it('toggle', async () => {
       channel.multiTrackUnselect();
       channel.multiTrackToggle();
-      expect(await firstValueFrom(channel.multiTrackSelected$)).toBe(1);
+      expect(await firstValueFrom(channel.multiTrackSelected$)).toBe(true);
 
       channel.multiTrackToggle();
-      expect(await firstValueFrom(channel.multiTrackSelected$)).toBe(0);
+      expect(await firstValueFrom(channel.multiTrackSelected$)).toBe(false);
     });
 
     it('should only work for input and line channels', () => {

--- a/packages/mixer-connection/src/lib/facade/master-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/master-channel.ts
@@ -2,7 +2,13 @@ import { map, take } from 'rxjs';
 
 import { MixerConnection } from '../mixer-connection';
 import { MixerStore } from '../state/mixer-store';
-import { select, selectPan, selectRawValue, selectSolo } from '../state/state-selectors';
+import {
+  select,
+  selectBoolean,
+  selectPan,
+  selectRawValue,
+  selectSolo,
+} from '../state/state-selectors';
 import { ChannelType } from '../types';
 import { clamp, getLinkedChannelNumber, roundToThreeDecimals } from '../utils';
 import { Channel } from './channel';
@@ -21,7 +27,7 @@ export class MasterChannel extends Channel implements PannableChannel {
   protected override fullChannelId = constructMasterChannelId(this.channelType, this.channel);
   override faderLevelCommand = 'mix';
 
-  /** SOLO value of the channel (`0` or `1`) */
+  /** SOLO state of the channel */
   readonly solo$ = this.store.state$.pipe(select(selectSolo(this.channelType, this.channel)));
 
   /** PAN value of the channel (between `0` and `1`) */
@@ -54,9 +60,9 @@ export class MasterChannel extends Channel implements PannableChannel {
     map(v => linearMappingValueToRange(v, -12, 12)),
   );
 
-  /** Multitrack selection state for the channel (`0` or `1`) */
+  /** Multitrack selection state for the channel */
   readonly multiTrackSelected$ = this.store.state$.pipe(
-    selectRawValue<number>(`${this.fullChannelId}.mtkrec`),
+    selectBoolean(`${this.fullChannelId}.mtkrec`),
   );
 
   constructor(conn: MixerConnection, store: MixerStore, channelType: ChannelType, channel: number) {
@@ -96,28 +102,28 @@ export class MasterChannel extends Channel implements PannableChannel {
   }
 
   /**
-   * Set SOLO value for the channel
-   * @param value SOLO value `0` or `1`
+   * Set SOLO state for the channel
+   * @param value SOLO state
    */
-  setSolo(value: number) {
+  setSolo(value: boolean) {
     [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
-      this.conn.setd(`${cid}.solo`, value);
+      this.conn.setdBool(`${cid}.solo`, value);
     });
   }
 
   /** Enable SOLO for the channel */
   solo() {
-    this.setSolo(1);
+    this.setSolo(true);
   }
 
   /** Disable SOLO for the channel */
   unsolo() {
-    this.setSolo(0);
+    this.setSolo(false);
   }
 
-  /** Toggle SOLO status for the channel */
+  /** Toggle SOLO state for the channel */
   toggleSolo() {
-    this.solo$.pipe(take(1)).subscribe(solo => this.setSolo(solo ^ 1));
+    this.solo$.pipe(take(1)).subscribe(solo => this.setSolo(!solo));
   }
 
   private multiTrackAssertChannelType() {
@@ -126,20 +132,20 @@ export class MasterChannel extends Channel implements PannableChannel {
     }
   }
 
-  private multiTrackSetSelection(value: number) {
+  private multiTrackSetSelection(value: boolean) {
     this.multiTrackAssertChannelType();
 
-    this.conn.setd(`${this.fullChannelId}.mtkrec`, value);
+    this.conn.setdBool(`${this.fullChannelId}.mtkrec`, value);
   }
 
   /** Select this channel for multitrack recording */
   multiTrackSelect() {
-    this.multiTrackSetSelection(1);
+    this.multiTrackSetSelection(true);
   }
 
   /** Remove this channel from multitrack recording */
   multiTrackUnselect() {
-    this.multiTrackSetSelection(0);
+    this.multiTrackSetSelection(false);
   }
 
   /** Toggle multitrack recording for this channel */
@@ -147,7 +153,7 @@ export class MasterChannel extends Channel implements PannableChannel {
     this.multiTrackAssertChannelType();
     this.multiTrackSelected$
       .pipe(take(1))
-      .subscribe(selected => this.multiTrackSetSelection(selected ^ 1));
+      .subscribe(selected => this.multiTrackSetSelection(!selected));
   }
 
   /** Assign this channel to an automix group. This also includes stereo-linked channels.

--- a/packages/mixer-connection/src/lib/facade/matrix-utils.ts
+++ b/packages/mixer-connection/src/lib/facade/matrix-utils.ts
@@ -12,22 +12,22 @@ import { getLinkedChannelNumber } from '../utils';
  * linked neighbour slot is switched as well, so a linked pair always stays
  * consistent (both AUX or both matrix). Matrix buses are only available on the Ui24R.
  *
- * @param value `1` to switch to matrix, `0` to switch back to a regular AUX bus
+ * @param value `true` to switch to matrix, `false` to switch back to a regular AUX bus
  */
 export function setMatrixMode(
   conn: MixerConnection,
   store: MixerStore,
   bus: number,
-  value: number,
+  value: boolean,
 ) {
   // always switch the slot itself
-  conn.setd(`a.${bus - 1}.matrix`, value);
+  conn.setdBool(`a.${bus - 1}.matrix`, value);
 
   // also switch the stereo-linked neighbour, if the slot is currently linked
   store.state$.pipe(select(selectStereoIndex('a', bus)), take(1)).subscribe(stereoIndex => {
     const linkedBus = getLinkedChannelNumber(bus, stereoIndex);
     if (linkedBus !== undefined) {
-      conn.setd(`a.${linkedBus - 1}.matrix`, value);
+      conn.setdBool(`a.${linkedBus - 1}.matrix`, value);
     }
   });
 }

--- a/packages/mixer-connection/src/lib/facade/mtx-bus-channel.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/mtx-bus-channel.spec.ts
@@ -45,19 +45,19 @@ describe('MTX Bus Channel', () => {
   describe('MUTE', () => {
     it('mute$', async () => {
       channel.mute();
-      expect(await firstValueFrom(channel.mute$)).toBe(1);
+      expect(await firstValueFrom(channel.mute$)).toBe(true);
 
       channel.unmute();
-      expect(await firstValueFrom(channel.mute$)).toBe(0);
+      expect(await firstValueFrom(channel.mute$)).toBe(false);
     });
 
     it('toggleMute', async () => {
-      channel.setMute(0);
+      channel.setMute(false);
       channel.toggleMute();
-      expect(await firstValueFrom(channel.mute$)).toBe(1);
+      expect(await firstValueFrom(channel.mute$)).toBe(true);
 
       channel.toggleMute();
-      expect(await firstValueFrom(channel.mute$)).toBe(0);
+      expect(await firstValueFrom(channel.mute$)).toBe(false);
     });
   });
 
@@ -94,13 +94,13 @@ describe('MTX Bus Channel', () => {
   describe('PRE/POST PROC', () => {
     it('postProc$', async () => {
       channel.postProc();
-      expect(await firstValueFrom(channel.postProc$)).toBe(1);
+      expect(await firstValueFrom(channel.postProc$)).toBe(true);
 
       channel.preProc();
-      expect(await firstValueFrom(channel.postProc$)).toBe(0);
+      expect(await firstValueFrom(channel.postProc$)).toBe(false);
 
-      channel.setPostProc(1);
-      expect(await firstValueFrom(channel.postProc$)).toBe(1);
+      channel.setPostProc(true);
+      expect(await firstValueFrom(channel.postProc$)).toBe(true);
     });
   });
 

--- a/packages/mixer-connection/src/lib/facade/mtx-bus.ts
+++ b/packages/mixer-connection/src/lib/facade/mtx-bus.ts
@@ -1,5 +1,3 @@
-import { map } from 'rxjs';
-
 import { MixerConnection } from '../mixer-connection';
 import { MixerStore } from '../state/mixer-store';
 import { select, selectMatrix } from '../state/state-selectors';
@@ -20,7 +18,7 @@ import { auxBusStoreId } from './object-store-ids';
  */
 export class MtxBus {
   /** Whether this bus is currently configured as a matrix bus (Ui24R only) */
-  readonly isMatrix$ = this.store.state$.pipe(select(selectMatrix(this.bus)), map(Boolean));
+  readonly isMatrix$ = this.store.state$.pipe(select(selectMatrix(this.bus)));
 
   constructor(
     private conn: MixerConnection,
@@ -66,7 +64,7 @@ export class MtxBus {
    * @returns the AUX bus (`AuxBus`) for the same slot
    */
   switchToAux(): AuxBus {
-    setMatrixMode(this.conn, this.store, this.bus, 0);
+    setMatrixMode(this.conn, this.store, this.bus, false);
     return this.store.objectStore.getOrCreate(
       auxBusStoreId(this.bus),
       () => new AuxBus(this.conn, this.store, this.bus),

--- a/packages/mixer-connection/src/lib/facade/mtx-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/mtx-channel.ts
@@ -2,7 +2,7 @@ import { Observable, Subject, map, take } from 'rxjs';
 
 import { MixerConnection } from '../mixer-connection';
 import { MixerStore } from '../state/mixer-store';
-import { selectRawValue } from '../state/state-selectors';
+import { selectBoolean, selectRawValue } from '../state/state-selectors';
 import { sourcesToTransition, TransitionSource } from '../transitions';
 import { clamp, roundToThreeDecimals } from '../utils';
 import { resolveDelayed } from '../utils/async-helpers';
@@ -35,16 +35,14 @@ export abstract class MtxChannel
   /** dB level of the matrix source (between `-Infinity` and `10`) */
   readonly faderLevelDB$ = this.faderLevel$.pipe(map(v => faderValueToDB(v)));
 
-  /** MUTE value of the matrix source (`0` or `1`) */
-  readonly mute$ = this.store.state$.pipe(selectRawValue<number>(`${this.fullChannelId}.mute`, 0));
+  /** MUTE state of the matrix source */
+  readonly mute$ = this.store.state$.pipe(selectBoolean(`${this.fullChannelId}.mute`));
 
   /** PAN value of the matrix source (between `0` and `1`) */
   readonly pan$ = this.store.state$.pipe(selectRawValue<number>(`${this.fullChannelId}.pan`, 0));
 
-  /** PRE/POST PROC value of the matrix source (`1` (POST PROC) or `0` (PRE PROC)) */
-  readonly postProc$ = this.store.state$.pipe(
-    selectRawValue<number>(`${this.fullChannelId}.postproc`, 0),
-  );
+  /** PRE/POST PROC state of the matrix source (`false` for PRE PROC, `true` for POST PROC) */
+  readonly postProc$ = this.store.state$.pipe(selectBoolean(`${this.fullChannelId}.postproc`));
 
   /** all linked channels (mirror on the stereo-linked matrix output and stereo-link neighbour) */
   protected linkedChannelIds: string[] = [];
@@ -134,28 +132,28 @@ export abstract class MtxChannel
   }
 
   /**
-   * Set MUTE value for the matrix source
-   * @param value MUTE value `0` or `1`
+   * Set MUTE state for the matrix source
+   * @param value MUTE state
    */
-  setMute(value: number) {
+  setMute(value: boolean) {
     [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
-      this.conn.setd(`${cid}.mute`, value);
+      this.conn.setdBool(`${cid}.mute`, value);
     });
   }
 
   /** Enable MUTE for the matrix source */
   mute() {
-    this.setMute(1);
+    this.setMute(true);
   }
 
   /** Disable MUTE for the matrix source */
   unmute() {
-    this.setMute(0);
+    this.setMute(false);
   }
 
-  /** Toggle MUTE status for the matrix source */
+  /** Toggle MUTE state for the matrix source */
   toggleMute() {
-    this.mute$.pipe(take(1)).subscribe(mute => this.setMute(mute ^ 1));
+    this.mute$.pipe(take(1)).subscribe(mute => this.setMute(!mute));
   }
 
   /**
@@ -181,22 +179,22 @@ export abstract class MtxChannel
   }
 
   /**
-   * Set PRE/POST PROC value for the matrix source
-   * @param value `1` (POST PROC) or `0` (PRE PROC)
+   * Set PRE/POST PROC state for the matrix source
+   * @param value POST PROC (`true`) or PRE PROC (`false`)
    */
-  setPostProc(value: number) {
+  setPostProc(value: boolean) {
     [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
-      this.conn.setd(`${cid}.postproc`, value);
+      this.conn.setdBool(`${cid}.postproc`, value);
     });
   }
 
   /** Set matrix source to POST PROC */
   postProc() {
-    this.setPostProc(1);
+    this.setPostProc(true);
   }
 
   /** Set matrix source to PRE PROC */
   preProc() {
-    this.setPostProc(0);
+    this.setPostProc(false);
   }
 }

--- a/packages/mixer-connection/src/lib/facade/mtx-master-channel.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/mtx-master-channel.spec.ts
@@ -48,19 +48,19 @@ describe('MTX Master Channel', () => {
   describe('MUTE', () => {
     it('mute$', async () => {
       channel.mute();
-      expect(await firstValueFrom(channel.mute$)).toBe(1);
+      expect(await firstValueFrom(channel.mute$)).toBe(true);
 
       channel.unmute();
-      expect(await firstValueFrom(channel.mute$)).toBe(0);
+      expect(await firstValueFrom(channel.mute$)).toBe(false);
     });
 
     it('toggleMute', async () => {
-      channel.setMute(0);
+      channel.setMute(false);
       channel.toggleMute();
-      expect(await firstValueFrom(channel.mute$)).toBe(1);
+      expect(await firstValueFrom(channel.mute$)).toBe(true);
 
       channel.toggleMute();
-      expect(await firstValueFrom(channel.mute$)).toBe(0);
+      expect(await firstValueFrom(channel.mute$)).toBe(false);
     });
   });
 
@@ -88,13 +88,13 @@ describe('MTX Master Channel', () => {
   describe('PRE/POST PROC', () => {
     it('postProc$', async () => {
       channel.postProc();
-      expect(await firstValueFrom(channel.postProc$)).toBe(1);
+      expect(await firstValueFrom(channel.postProc$)).toBe(true);
 
       channel.preProc();
-      expect(await firstValueFrom(channel.postProc$)).toBe(0);
+      expect(await firstValueFrom(channel.postProc$)).toBe(false);
 
-      channel.setPostProc(1);
-      expect(await firstValueFrom(channel.postProc$)).toBe(1);
+      channel.setPostProc(true);
+      expect(await firstValueFrom(channel.postProc$)).toBe(true);
     });
   });
 });

--- a/packages/mixer-connection/src/lib/facade/multi-track-recorder.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/multi-track-recorder.spec.ts
@@ -54,18 +54,18 @@ describe('Multi-track recorder', () => {
 
   it('recording$', async () => {
     conn.conn.sendMessage('SETD^var.mtk.rec.currentState^0');
-    expect(await firstValueFrom(mtk.recording$)).toBe(0);
+    expect(await firstValueFrom(mtk.recording$)).toBe(false);
 
     conn.conn.sendMessage('SETD^var.mtk.rec.currentState^1');
-    expect(await firstValueFrom(mtk.recording$)).toBe(1);
+    expect(await firstValueFrom(mtk.recording$)).toBe(true);
   });
 
   it('busy$', async () => {
     conn.conn.sendMessage('SETD^var.mtk.rec.busy^1');
-    expect(await firstValueFrom(mtk.busy$)).toBe(1);
+    expect(await firstValueFrom(mtk.busy$)).toBe(true);
 
     conn.conn.sendMessage('SETD^var.mtk.rec.busy^0');
-    expect(await firstValueFrom(mtk.busy$)).toBe(0);
+    expect(await firstValueFrom(mtk.busy$)).toBe(false);
   });
 
   describe('recordingTime$', () => {
@@ -85,35 +85,35 @@ describe('Multi-track recorder', () => {
   describe('Soundcheck', () => {
     it('soundcheck$', async () => {
       conn.conn.sendMessage('SETD^var.mtk.soundcheck^0');
-      expect(await firstValueFrom(mtk.soundcheck$)).toBe(0);
+      expect(await firstValueFrom(mtk.soundcheck$)).toBe(false);
 
       conn.conn.sendMessage('SETD^var.mtk.soundcheck^1');
-      expect(await firstValueFrom(mtk.soundcheck$)).toBe(1);
+      expect(await firstValueFrom(mtk.soundcheck$)).toBe(true);
     });
 
     it('setSoundcheck', async () => {
-      mtk.setSoundcheck(0);
-      expect(await firstValueFrom(mtk.soundcheck$)).toBe(0);
+      mtk.setSoundcheck(false);
+      expect(await firstValueFrom(mtk.soundcheck$)).toBe(false);
 
-      mtk.setSoundcheck(1);
-      expect(await firstValueFrom(mtk.soundcheck$)).toBe(1);
+      mtk.setSoundcheck(true);
+      expect(await firstValueFrom(mtk.soundcheck$)).toBe(true);
     });
 
     it('activate/deactivateSoundcheck', async () => {
       mtk.activateSoundcheck();
-      expect(await firstValueFrom(mtk.soundcheck$)).toBe(1);
+      expect(await firstValueFrom(mtk.soundcheck$)).toBe(true);
 
       mtk.deactivateSoundcheck();
-      expect(await firstValueFrom(mtk.soundcheck$)).toBe(0);
+      expect(await firstValueFrom(mtk.soundcheck$)).toBe(false);
     });
 
     it('toggleSoundcheck', async () => {
-      mtk.setSoundcheck(0);
+      mtk.setSoundcheck(false);
       mtk.toggleSoundcheck();
-      expect(await firstValueFrom(mtk.soundcheck$)).toBe(1);
+      expect(await firstValueFrom(mtk.soundcheck$)).toBe(true);
 
       mtk.toggleSoundcheck();
-      expect(await firstValueFrom(mtk.soundcheck$)).toBe(0);
+      expect(await firstValueFrom(mtk.soundcheck$)).toBe(false);
     });
   });
 

--- a/packages/mixer-connection/src/lib/facade/multi-track-recorder.ts
+++ b/packages/mixer-connection/src/lib/facade/multi-track-recorder.ts
@@ -3,6 +3,7 @@ import { MixerConnection } from '../mixer-connection';
 import { MixerStore } from '../state/mixer-store';
 import {
   select,
+  selectBoolean,
   selectMtkElapsedTime,
   selectMtkLength,
   selectMtkRemainingTime,
@@ -41,11 +42,11 @@ export class MultiTrackRecorder {
   /** Remaining time of current session in seconds */
   readonly remainingTime$ = this.store.state$.pipe(select(selectMtkRemainingTime()));
 
-  /** Recording state (`0` or `1`) */
-  readonly recording$ = this.store.state$.pipe(selectRawValue('var.mtk.rec.currentState', 0));
+  /** Recording state */
+  readonly recording$ = this.store.state$.pipe(selectBoolean('var.mtk.rec.currentState'));
 
-  /** Recording busy state (`0` or `1`) */
-  readonly busy$ = this.store.state$.pipe(selectRawValue('var.mtk.rec.busy', 0));
+  /** Recording busy state */
+  readonly busy$ = this.store.state$.pipe(selectBoolean('var.mtk.rec.busy'));
 
   /** Recording time in seconds */
   readonly recordingTime$ = this.store.state$.pipe(
@@ -54,8 +55,8 @@ export class MultiTrackRecorder {
     map(([value, recording]) => (recording ? value : 0)), // set to 0 if not actually recording. otherwise, it emits strange values
   );
 
-  /** Soundcheck activation state (`0` or `1`) */
-  readonly soundcheck$ = this.store.state$.pipe(selectRawValue('var.mtk.soundcheck', 0));
+  /** Soundcheck activation state */
+  readonly soundcheck$ = this.store.state$.pipe(selectBoolean('var.mtk.soundcheck'));
 
   constructor(
     private conn: MixerConnection,
@@ -104,24 +105,24 @@ export class MultiTrackRecorder {
 
   /**
    * Set soundcheck (activate or deactivate)
-   * @param value `0` or `1`
+   * @param value soundcheck activation state
    */
-  setSoundcheck(value: number) {
-    this.conn.setd('var.mtk.soundcheck', value);
+  setSoundcheck(value: boolean) {
+    this.conn.setdBool('var.mtk.soundcheck', value);
   }
 
   /** Activate soundcheck */
   activateSoundcheck() {
-    this.setSoundcheck(1);
+    this.setSoundcheck(true);
   }
 
   /** Deactivate soundcheck */
   deactivateSoundcheck() {
-    this.setSoundcheck(0);
+    this.setSoundcheck(false);
   }
 
   /** Toggle soundcheck */
   toggleSoundcheck() {
-    this.soundcheck$.pipe(take(1)).subscribe(value => this.setSoundcheck(value ^ 1));
+    this.soundcheck$.pipe(take(1)).subscribe(value => this.setSoundcheck(!value));
   }
 }

--- a/packages/mixer-connection/src/lib/facade/multi-track-recorder.ts
+++ b/packages/mixer-connection/src/lib/facade/multi-track-recorder.ts
@@ -21,17 +21,7 @@ export class MultiTrackRecorder {
   );
 
   /** Current session name (e.g. `0001` or individual name) */
-  readonly session$ = this.store.state$.pipe(
-    selectRawValue<number | string>('var.mtk.session'),
-    map(value => {
-      if (typeof value === 'number') {
-        // convert to 4-digit string
-        return value.toString().padStart(4, '0');
-      } else {
-        return value;
-      }
-    }),
-  );
+  readonly session$ = this.store.state$.pipe(selectRawValue<string>('var.mtk.session'));
 
   /** Current session length in seconds */
   readonly length$ = this.store.state$.pipe(select(selectMtkLength()));

--- a/packages/mixer-connection/src/lib/facade/mute-group.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/mute-group.spec.ts
@@ -23,18 +23,18 @@ describe('Mute Group', () => {
 
     it('state$', async () => {
       group.mute();
-      expect(await firstValueFrom(group.state$)).toBe(1);
+      expect(await firstValueFrom(group.state$)).toBe(true);
 
       group.unmute();
-      expect(await firstValueFrom(group.state$)).toBe(0);
+      expect(await firstValueFrom(group.state$)).toBe(false);
     });
 
     it('toggle', async () => {
       group.toggle();
-      expect(await firstValueFrom(group.state$)).toBe(1);
+      expect(await firstValueFrom(group.state$)).toBe(true);
 
       group.toggle();
-      expect(await firstValueFrom(group.state$)).toBe(0);
+      expect(await firstValueFrom(group.state$)).toBe(false);
     });
   });
 
@@ -43,18 +43,18 @@ describe('Mute Group', () => {
 
     it('state$', async () => {
       group.mute();
-      expect(await firstValueFrom(group.state$)).toBe(1);
+      expect(await firstValueFrom(group.state$)).toBe(true);
 
       group.unmute();
-      expect(await firstValueFrom(group.state$)).toBe(0);
+      expect(await firstValueFrom(group.state$)).toBe(false);
     });
 
     it('toggle', async () => {
       group.toggle();
-      expect(await firstValueFrom(group.state$)).toBe(1);
+      expect(await firstValueFrom(group.state$)).toBe(true);
 
       group.toggle();
-      expect(await firstValueFrom(group.state$)).toBe(0);
+      expect(await firstValueFrom(group.state$)).toBe(false);
     });
   });
 
@@ -63,18 +63,18 @@ describe('Mute Group', () => {
 
     it('state$', async () => {
       group.mute();
-      expect(await firstValueFrom(group.state$)).toBe(1);
+      expect(await firstValueFrom(group.state$)).toBe(true);
 
       group.unmute();
-      expect(await firstValueFrom(group.state$)).toBe(0);
+      expect(await firstValueFrom(group.state$)).toBe(false);
     });
 
     it('toggle', async () => {
       group.toggle();
-      expect(await firstValueFrom(group.state$)).toBe(1);
+      expect(await firstValueFrom(group.state$)).toBe(true);
 
       group.toggle();
-      expect(await firstValueFrom(group.state$)).toBe(0);
+      expect(await firstValueFrom(group.state$)).toBe(false);
     });
   });
 });

--- a/packages/mixer-connection/src/lib/facade/mute-group.ts
+++ b/packages/mixer-connection/src/lib/facade/mute-group.ts
@@ -34,7 +34,7 @@ export class MuteGroup {
 
   private mgMask$ = this.store.state$.pipe(selectRawValue<number>('mgmask'));
 
-  /** MUTE state of the group (`0` or `1`) */
+  /** MUTE state of the group */
   readonly state$ = this.mgMask$.pipe(map(value => getValueOfBit(value, this.groupIndex)));
 
   /** Mute the MUTE group */

--- a/packages/mixer-connection/src/lib/facade/player.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/player.spec.ts
@@ -53,20 +53,20 @@ describe('Player', () => {
 
   describe('Shuffle', () => {
     it('shuffle$', async () => {
-      player.setShuffle(0);
-      expect(await firstValueFrom(player.shuffle$)).toBe(0);
+      player.setShuffle(false);
+      expect(await firstValueFrom(player.shuffle$)).toBe(false);
 
-      player.setShuffle(1);
-      expect(await firstValueFrom(player.shuffle$)).toBe(1);
+      player.setShuffle(true);
+      expect(await firstValueFrom(player.shuffle$)).toBe(true);
     });
 
     it('toggleShuffle', async () => {
-      player.setShuffle(0);
+      player.setShuffle(false);
       player.toggleShuffle();
-      expect(await firstValueFrom(player.shuffle$)).toBe(1);
+      expect(await firstValueFrom(player.shuffle$)).toBe(true);
 
       player.toggleShuffle();
-      expect(await firstValueFrom(player.shuffle$)).toBe(0);
+      expect(await firstValueFrom(player.shuffle$)).toBe(false);
     });
   });
 });

--- a/packages/mixer-connection/src/lib/facade/player.ts
+++ b/packages/mixer-connection/src/lib/facade/player.ts
@@ -4,6 +4,7 @@ import { MixerConnection } from '../mixer-connection';
 import { MixerStore } from '../state/mixer-store';
 import {
   select,
+  selectBoolean,
   selectPlayerElapsedTime,
   selectPlayerLength,
   selectPlayerRemainingTime,
@@ -35,8 +36,8 @@ export class Player {
   /** Remaining time of current track in seconds */
   readonly remainingTime$ = this.store.state$.pipe(select(selectPlayerRemainingTime()));
 
-  /** Shuffle setting (`0` or `1`) */
-  readonly shuffle$ = this.store.state$.pipe(selectRawValue('settings.shuffle', 0));
+  /** Shuffle state */
+  readonly shuffle$ = this.store.state$.pipe(selectBoolean('settings.shuffle'));
 
   constructor(
     private conn: MixerConnection,
@@ -86,18 +87,18 @@ export class Player {
   }
 
   /**
-   * Set player shuffle setting
-   * @param value `0` or `1`
+   * Set player shuffle state
+   * @param value shuffle state
    */
-  setShuffle(value: number) {
-    this.conn.setd('settings.shuffle', value);
+  setShuffle(value: boolean) {
+    this.conn.setdBool('settings.shuffle', value);
   }
 
   /**
-   * Toggle player shuffle setting
+   * Toggle player shuffle state
    */
   toggleShuffle() {
-    this.shuffle$.pipe(take(1)).subscribe(value => this.setShuffle(value ^ 1));
+    this.shuffle$.pipe(take(1)).subscribe(value => this.setShuffle(!value));
   }
 
   /**

--- a/packages/mixer-connection/src/lib/facade/send-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/send-channel.ts
@@ -20,7 +20,7 @@ export class SendChannel extends Channel {
   );
   override faderLevelCommand = 'value';
 
-  /** PRE/POST value of the channel (`1` (POST) or `0` (PRE)) */
+  /** PRE/POST state of the channel (`false` for PRE, `true` for POST) */
   readonly post$ = this.store.state$.pipe(
     select(selectPost(this.channelType, this.channel, this.busType, this.bus)),
   );
@@ -37,27 +37,27 @@ export class SendChannel extends Channel {
   }
 
   /**
-   * Set PRE/POST value for the channel
-   * @param value `1` (POST) or `0` (PRE)
+   * Set PRE/POST state for the channel
+   * @param value POST (`true`) or PRE (`false`)
    */
-  setPost(value: number) {
+  setPost(value: boolean) {
     [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
-      this.conn.setd(`${cid}.post`, value);
+      this.conn.setdBool(`${cid}.post`, value);
     });
   }
 
   /** Set AUX channel to POST */
   post() {
-    this.setPost(1);
+    this.setPost(true);
   }
 
   /** Set AUX channel to PRE */
   pre() {
-    this.setPost(0);
+    this.setPost(false);
   }
 
-  /** Toggle PRE/POST status of the channel */
+  /** Toggle PRE/POST state of the channel */
   togglePost() {
-    this.post$.pipe(take(1)).subscribe(post => this.setPost(post ^ 1));
+    this.post$.pipe(take(1)).subscribe(post => this.setPost(!post));
   }
 }

--- a/packages/mixer-connection/src/lib/mixer-connection.spec.ts
+++ b/packages/mixer-connection/src/lib/mixer-connection.spec.ts
@@ -116,6 +116,44 @@ describe('MixerConnection', () => {
     });
   });
 
+  describe('setd()', () => {
+    it('should send a SETD message with the numeric value', () => {
+      conn.sendMessage = vi.fn();
+
+      conn.setd('m.mix', 0.5);
+
+      expect(conn.sendMessage).toHaveBeenCalledWith('SETD^m.mix^0.5');
+    });
+  });
+
+  describe('sets()', () => {
+    it('should send a SETS message with the string value', () => {
+      conn.sendMessage = vi.fn();
+
+      conn.sets('i.0.name', 'Vocals');
+
+      expect(conn.sendMessage).toHaveBeenCalledWith('SETS^i.0.name^Vocals');
+    });
+  });
+
+  describe('setdBool()', () => {
+    it('should send a SETD message with 1 for true', () => {
+      conn.sendMessage = vi.fn();
+
+      conn.setdBool('i.0.mute', true);
+
+      expect(conn.sendMessage).toHaveBeenCalledWith('SETD^i.0.mute^1');
+    });
+
+    it('should send a SETD message with 0 for false', () => {
+      conn.sendMessage = vi.fn();
+
+      conn.setdBool('i.0.mute', false);
+
+      expect(conn.sendMessage).toHaveBeenCalledWith('SETD^i.0.mute^0');
+    });
+  });
+
   describe('disconnect()', () => {
     beforeEach(async () => {
       const connectPromise = conn.connect();

--- a/packages/mixer-connection/src/lib/mixer-connection.ts
+++ b/packages/mixer-connection/src/lib/mixer-connection.ts
@@ -235,6 +235,16 @@ export class MixerConnection {
   }
 
   /**
+   * Send a `SETD` command with a boolean (on/off) value to the mixer.
+   * The boolean is converted to the numeric `0`/`1` the protocol expects.
+   * @param path Parameter path, e.g. `i.2.mute`
+   * @param value Boolean value to set
+   */
+  setdBool(path: string, value: boolean) {
+    this.sendMessage(`SETD^${path}^${Number(value)}`);
+  }
+
+  /**
    * Send a `SETS` command to the mixer.
    * `SETS` messages carry string values, e.g. channel names.
    * @param path Parameter path, e.g. `i.2.name`

--- a/packages/mixer-connection/src/lib/state/state-selectors.spec.ts
+++ b/packages/mixer-connection/src/lib/state/state-selectors.spec.ts
@@ -4,6 +4,7 @@ import { of, firstValueFrom } from 'rxjs';
 import {
   select,
   selectRawValue,
+  selectBoolean,
   selectMasterValue,
   selectMasterPan,
   selectMasterDim,
@@ -74,6 +75,28 @@ describe('State Selectors', () => {
     });
   });
 
+  describe('selectBoolean', () => {
+    it('should coerce 1 to true', async () => {
+      const result = await firstValueFrom(of({ 'i.0.mute': 1 }).pipe(selectBoolean('i.0.mute')));
+      expect(result).toBe(true);
+    });
+
+    it('should coerce 0 to false', async () => {
+      const result = await firstValueFrom(of({ 'i.0.mute': 0 }).pipe(selectBoolean('i.0.mute')));
+      expect(result).toBe(false);
+    });
+
+    it('should default to false when the path is missing', async () => {
+      const result = await firstValueFrom(of({}).pipe(selectBoolean('missing.path')));
+      expect(result).toBe(false);
+    });
+
+    it('should use the given default value when the path is missing', async () => {
+      const result = await firstValueFrom(of({}).pipe(selectBoolean('missing.path', true)));
+      expect(result).toBe(true);
+    });
+  });
+
   describe('Master selectors', () => {
     it('selectMasterValue should read m.mix', () => {
       const projector = selectMasterValue();
@@ -87,7 +110,7 @@ describe('State Selectors', () => {
 
     it('selectMasterDim should read m.dim', () => {
       const projector = selectMasterDim();
-      expect(projector({ 'm.dim': 1 })).toBe(1);
+      expect(projector({ 'm.dim': 1 })).toBe(true);
     });
 
     it('selectMasterDelay L should read m.delayL and multiply by 1000', () => {
@@ -137,27 +160,27 @@ describe('State Selectors', () => {
     describe('selectMute', () => {
       it('should read mute for master bus', () => {
         const projector = selectMute('i', 1, 'master');
-        expect(projector({ 'i.0.mute': 1 })).toBe(1);
+        expect(projector({ 'i.0.mute': 1 })).toBe(true);
       });
 
-      it('should default to 0 for master bus', () => {
+      it('should default to false for master bus', () => {
         const projector = selectMute('i', 1, 'master');
-        expect(projector({})).toBe(0);
+        expect(projector({})).toBe(false);
       });
 
       it('should read mute for aux bus', () => {
         const projector = selectMute('i', 2, 'aux', 1);
-        expect(projector({ 'i.1.aux.0.mute': 1 })).toBe(1);
+        expect(projector({ 'i.1.aux.0.mute': 1 })).toBe(true);
       });
 
       it('should read mute for fx bus', () => {
         const projector = selectMute('l', 3, 'fx', 2);
-        expect(projector({ 'l.2.fx.1.mute': 1 })).toBe(1);
+        expect(projector({ 'l.2.fx.1.mute': 1 })).toBe(true);
       });
 
       it('should read mute for mtx bus', () => {
         const projector = selectMute('s', 1, 'mtx', 7);
-        expect(projector({ 's.0.mtx.6.mute': 1 })).toBe(1);
+        expect(projector({ 's.0.mtx.6.mute': 1 })).toBe(true);
       });
     });
 
@@ -187,12 +210,12 @@ describe('State Selectors', () => {
   describe('selectSolo', () => {
     it('should read solo state for a channel', () => {
       const projector = selectSolo('i', 3);
-      expect(projector({ 'i.2.solo': 1 })).toBe(1);
+      expect(projector({ 'i.2.solo': 1 })).toBe(true);
     });
 
-    it('should return undefined when path is missing', () => {
+    it('should return false when path is missing', () => {
       const projector = selectSolo('i', 3);
-      expect(projector({})).toBeUndefined();
+      expect(projector({})).toBe(false);
     });
   });
 
@@ -211,29 +234,29 @@ describe('State Selectors', () => {
   describe('selectPost', () => {
     it('should read post value for a send channel', () => {
       const projector = selectPost('i', 3, 'aux', 2);
-      expect(projector({ 'i.2.aux.1.post': 1 })).toBe(1);
+      expect(projector({ 'i.2.aux.1.post': 1 })).toBe(true);
     });
 
-    it('should default to 0', () => {
+    it('should default to false', () => {
       const projector = selectPost('i', 3, 'aux', 2);
-      expect(projector({})).toBe(0);
+      expect(projector({})).toBe(false);
     });
   });
 
   describe('selectPostProc', () => {
     it('should read postproc value for an aux send', () => {
       const projector = selectPostProc('i', 4, 'aux', 2);
-      expect(projector({ 'i.3.aux.1.postproc': 1 })).toBe(1);
+      expect(projector({ 'i.3.aux.1.postproc': 1 })).toBe(true);
     });
 
     it('should read postproc value for a matrix send', () => {
       const projector = selectPostProc('a', 1, 'mtx', 7);
-      expect(projector({ 'a.0.mtx.6.postproc': 1 })).toBe(1);
+      expect(projector({ 'a.0.mtx.6.postproc': 1 })).toBe(true);
     });
 
-    it('should default to 0', () => {
+    it('should default to false', () => {
       const projector = selectPostProc('i', 4, 'aux', 2);
-      expect(projector({})).toBe(0);
+      expect(projector({})).toBe(false);
     });
   });
 
@@ -301,24 +324,24 @@ describe('State Selectors', () => {
   describe('selectMatrix', () => {
     it('should read matrix state for an AUX/matrix bus', () => {
       const projector = selectMatrix(7);
-      expect(projector({ 'a.6.matrix': 1 })).toBe(1);
+      expect(projector({ 'a.6.matrix': 1 })).toBe(true);
     });
 
-    it('should default to 0 when path is missing', () => {
+    it('should default to false when path is missing', () => {
       const projector = selectMatrix(7);
-      expect(projector({})).toBe(0);
+      expect(projector({})).toBe(false);
     });
   });
 
   describe('selectPhantom', () => {
     it('should read phantom state with hw key', () => {
       const projector = selectPhantom(3, 'hw');
-      expect(projector({ 'hw.2.phantom': 1 })).toBe(1);
+      expect(projector({ 'hw.2.phantom': 1 })).toBe(true);
     });
 
     it('should read phantom state with i key', () => {
       const projector = selectPhantom(1, 'i');
-      expect(projector({ 'i.0.phantom': 1 })).toBe(1);
+      expect(projector({ 'i.0.phantom': 1 })).toBe(true);
     });
   });
 

--- a/packages/mixer-connection/src/lib/state/state-selectors.ts
+++ b/packages/mixer-connection/src/lib/state/state-selectors.ts
@@ -25,6 +25,15 @@ export const select = <T>(projector: Projector<T>): OperatorFunction<unknown, T>
 export const selectRawValue = <T>(path: string, defaultValue?: T) =>
   select(state => getValueFromObject<T>(state, path, defaultValue));
 
+/**
+ * RxJS operator to select a boolean (on/off) value from the mixer state.
+ * The underlying numeric `0`/`1` value is coerced to `false`/`true`.
+ * @param path State key to select
+ * @param defaultValue Value to use when the state key is absent (default `false`)
+ */
+export const selectBoolean = (path: string, defaultValue = false) =>
+  select(state => Boolean(getValueFromObject<unknown>(state, path, defaultValue)));
+
 /**************************** */
 
 /**
@@ -74,8 +83,8 @@ export const selectMasterPan: Selector<number> = () => state =>
 /**
  * Select dim value of the master fader
  */
-export const selectMasterDim: Selector<number> = () => state =>
-  getValueFromObject<number>(state, 'm.dim');
+export const selectMasterDim: Selector<boolean> = () => state =>
+  Boolean(getValueFromObject<number>(state, 'm.dim'));
 
 /**
  * Select delay value of the master output (L or R)
@@ -104,21 +113,24 @@ export const selectPan: Selector<number> = (
  * @param busType
  * @param bus
  */
-export const selectMute: Selector<number> = (
+export const selectMute: Selector<boolean> = (
   channelType: ChannelType,
   channel: number,
   busType: BusType,
   bus?: number,
-) => selectGenericChannelProperty('mute', 0, channelType, channel, busType, bus);
+) => {
+  const projector = selectGenericChannelProperty('mute', 0, channelType, channel, busType, bus);
+  return state => Boolean(projector(state));
+};
 
 /**
  * Select solo value of a channel
  * @param channelType
  * @param channel
  */
-export const selectSolo: Selector<number> = (channelType: ChannelType, channel: number) => {
+export const selectSolo: Selector<boolean> = (channelType: ChannelType, channel: number) => {
   const path = joinStatePath(channelType, channel - 1, 'solo');
-  return state => getValueFromObject<number>(state, path);
+  return state => Boolean(getValueFromObject<number>(state, path));
 };
 
 /**
@@ -165,14 +177,14 @@ export const selectDelayValue: Selector<number> = (channelType: ChannelType, cha
  * @param channelType
  * @param channel
  */
-export const selectPost: Selector<number> = (
+export const selectPost: Selector<boolean> = (
   channelType: ChannelType,
   channel: number,
   busType: BusType,
   bus: number,
 ) => {
   const path = joinStatePath(channelType, channel - 1, busType, bus - 1, 'post');
-  return state => getValueFromObject(state, path, 0);
+  return state => Boolean(getValueFromObject(state, path, 0));
 };
 
 /**
@@ -182,12 +194,15 @@ export const selectPost: Selector<number> = (
  * @param busType
  * @param bus
  */
-export const selectPostProc: Selector<number> = (
+export const selectPostProc: Selector<boolean> = (
   channelType: ChannelType,
   channel: number,
   busType: BusType,
   bus?: number,
-) => selectGenericChannelProperty('postproc', 0, channelType, channel, busType, bus);
+) => {
+  const projector = selectGenericChannelProperty('postproc', 0, channelType, channel, busType, bus);
+  return state => Boolean(projector(state));
+};
 
 /**
  * Select BPM value of an FX bus
@@ -227,12 +242,12 @@ export const selectStereoIndex: Selector<number> = (channelType: ChannelType, ch
 
 /**
  * Select whether an AUX bus is currently configured as a matrix bus.
- * Only available on the Ui24R. Returns `0` or `1`.
+ * Only available on the Ui24R. Returns `true` or `false`.
  * @param bus AUX/matrix bus number
  */
-export const selectMatrix: Selector<number> = (bus: number) => {
+export const selectMatrix: Selector<boolean> = (bus: number) => {
   const path = joinStatePath('a', bus - 1, 'matrix');
-  return state => getValueFromObject(state, path, 0);
+  return state => Boolean(getValueFromObject(state, path, 0));
 };
 
 /**
@@ -240,9 +255,9 @@ export const selectMatrix: Selector<number> = (bus: number) => {
  * @param channel
  * @param key Type of the channel: `hw` or `i`, according to the mixer model
  */
-export const selectPhantom: Selector<number> = (channel: number, key: 'hw' | 'i') => {
+export const selectPhantom: Selector<boolean> = (channel: number, key: 'hw' | 'i') => {
   const path = joinStatePath(key, channel - 1, 'phantom');
-  return state => getValueFromObject<number>(state, path);
+  return state => Boolean(getValueFromObject<number>(state, path));
 };
 
 /**

--- a/packages/mixer-connection/src/lib/utils/bitmask.spec.ts
+++ b/packages/mixer-connection/src/lib/utils/bitmask.spec.ts
@@ -59,19 +59,19 @@ describe('Bit Mask Utils', () => {
   });
 
   describe('getValueOfBit', () => {
-    it('should get 0', () => {
+    it('should get false for an unset bit', () => {
       const result = getValueOfBit(0b1010100, 3);
-      expect(result).toBe(0);
+      expect(result).toBe(false);
     });
 
-    it('should get 1', () => {
+    it('should get true for a set bit', () => {
       const result = getValueOfBit(0b1010100, 2);
-      expect(result).toBe(1);
+      expect(result).toBe(true);
     });
 
-    it('should ignore negative bit index', () => {
+    it('should return false for a negative bit index', () => {
       const result = getValueOfBit(0b100, -5);
-      expect(result.toString(2)).toBe('100');
+      expect(result).toBe(false);
     });
   });
 });

--- a/packages/mixer-connection/src/lib/utils/bitmask.ts
+++ b/packages/mixer-connection/src/lib/utils/bitmask.ts
@@ -35,13 +35,13 @@ export function setBit(value: number, bitIndex: number) {
 }
 
 /**
- * Return the value of a specific bit in `value`
+ * Return whether a specific bit in `value` is set
  * @param value Source value
  * @param bitIndex Bit index, right to left
  */
-export function getValueOfBit(value: number, bitIndex: number) {
+export function getValueOfBit(value: number, bitIndex: number): boolean {
   if (bitIndex < 0) {
-    return value;
+    return false;
   }
-  return value & (1 << bitIndex) ? 1 : 0;
+  return Boolean(value & (1 << bitIndex));
 }

--- a/packages/testbed/src/app/pages/automix-page/automix-page.html
+++ b/packages/testbed/src/app/pages/automix-page/automix-page.html
@@ -20,7 +20,7 @@
   <h2>{{ g.label }}</h2>
   <sui-mixer-button (press)="g.group.enable()">Enable</sui-mixer-button>
   <sui-mixer-button (press)="g.group.disable()">Disable</sui-mixer-button>
-  <sui-mixer-button (press)="g.group.toggle()" [active]="!!(g.group.state$ | async)">Toggle</sui-mixer-button>
+  <sui-mixer-button (press)="g.group.toggle()" [active]="g.group.state$ | async">Toggle</sui-mixer-button>
 </div>
 } @for (c of channels; track c) {
 <div class="mb-4">

--- a/packages/testbed/src/app/pages/hwchannels-page/hwchannels-page.html
+++ b/packages/testbed/src/app/pages/hwchannels-page/hwchannels-page.html
@@ -3,7 +3,7 @@
 <h3>Phantom Power</h3>
 <sui-mixer-button (press)="channel.phantomOn()">ON</sui-mixer-button>
 <sui-mixer-button (press)="channel.phantomOff()">OFF</sui-mixer-button>
-<sui-mixer-button (press)="channel.togglePhantom()" [active]="!!(channel.phantom$ | async)">
+<sui-mixer-button (press)="channel.togglePhantom()" [active]="channel.phantom$ | async">
   Toggle
 </sui-mixer-button>
 <div class="mt-3">

--- a/packages/testbed/src/app/pages/master-page/master-page.html
+++ b/packages/testbed/src/app/pages/master-page/master-page.html
@@ -4,7 +4,7 @@
 <sui-transition-controls [channel]="master" />
 
 <div>
-  <sui-mixer-button activeClass="dim" [active]="!!(master.dim$ | async)" (press)="master.toggleDim()">
+  <sui-mixer-button activeClass="dim" [active]="master.dim$ | async" (press)="master.toggleDim()">
     DIM toggle
   </sui-mixer-button>
 

--- a/packages/testbed/src/app/pages/mtx-bus-page/mtx-bus-page.html
+++ b/packages/testbed/src/app/pages/mtx-bus-page/mtx-bus-page.html
@@ -36,7 +36,7 @@
 </div>
 @for (s of vm.sources; track s.label) {
 <h2 class="mt-4">{{ s.label }} ({{ s.channel.name$ | async }})</h2>
-<sui-mixer-button [active]="(s.channel.mute$ | async) === 1" (press)="s.channel.toggleMute()">
+<sui-mixer-button [active]="s.channel.mute$ | async" (press)="s.channel.toggleMute()">
   MUTE
 </sui-mixer-button>
 <sui-postproc-controls [channel]="s.channel" />

--- a/packages/testbed/src/app/pages/multitrack-page/multitrack-page.html
+++ b/packages/testbed/src/app/pages/multitrack-page/multitrack-page.html
@@ -13,7 +13,7 @@
   <sui-mixer-button (press)="mtk.play()">PLAY</sui-mixer-button>
   <sui-mixer-button (press)="mtk.pause()">PAUSE</sui-mixer-button>
   <sui-mixer-button (press)="mtk.stop()">STOP</sui-mixer-button>
-  <sui-mixer-button (press)="mtk.recordToggle()" [active]="!!(mtk.recording$ | async)">
+  <sui-mixer-button (press)="mtk.recordToggle()" [active]="mtk.recording$ | async">
     REC
   </sui-mixer-button>
   <sui-mixer-button (press)="mtk.recordStart()">REC Start</sui-mixer-button>
@@ -24,7 +24,7 @@
   <h2>Soundcheck</h2>
   <sui-mixer-button (press)="mtk.activateSoundcheck()">Activate</sui-mixer-button>
   <sui-mixer-button (press)="mtk.deactivateSoundcheck()">Deactivate</sui-mixer-button>
-  <sui-mixer-button (press)="mtk.toggleSoundcheck()" [active]="!!(mtk.soundcheck$ | async)">
+  <sui-mixer-button (press)="mtk.toggleSoundcheck()" [active]="mtk.soundcheck$ | async">
     Toggle
   </sui-mixer-button>
 </div>
@@ -38,7 +38,7 @@
     <sui-mixer-button (press)="c.channel.multiTrackUnselect()">Unselect</sui-mixer-button>
     <sui-mixer-button
       (press)="c.channel.multiTrackToggle()"
-      [active]="!!(c.channel.multiTrackSelected$ | async)"
+      [active]="c.channel.multiTrackSelected$ | async"
       >Toggle</sui-mixer-button
     >
   </div>

--- a/packages/testbed/src/app/pages/mute-groups-page/mute-groups-page.html
+++ b/packages/testbed/src/app/pages/mute-groups-page/mute-groups-page.html
@@ -4,7 +4,7 @@
 
 @for (g of groups; track g) {
 <div>
-  <sui-mixer-button activeClass="mute" [active]="!!(g.state$ | async)" (press)="g.toggle()">
+  <sui-mixer-button activeClass="mute" [active]="g.state$ | async" (press)="g.toggle()">
     Toggle {{ g.id }}
   </sui-mixer-button>
   <sui-mixer-button (press)="g.mute()">Mute {{ g.id }}</sui-mixer-button>

--- a/packages/testbed/src/app/pages/player-page/player-page.html
+++ b/packages/testbed/src/app/pages/player-page/player-page.html
@@ -37,11 +37,11 @@
   <sui-mixer-button (press)="player.setAuto()">Auto</sui-mixer-button>
 </div>
 <div>
-  <sui-mixer-button (press)="player.toggleShuffle()" [active]="!!(player.shuffle$ | async)">
+  <sui-mixer-button (press)="player.toggleShuffle()" [active]="player.shuffle$ | async">
     Shuffle Toggle
   </sui-mixer-button>
-  <sui-mixer-button (press)="player.setShuffle(1)">Shuffle On</sui-mixer-button>
-  <sui-mixer-button (press)="player.setShuffle(0)">Shuffle Off</sui-mixer-button>
+  <sui-mixer-button (press)="player.setShuffle(true)">Shuffle On</sui-mixer-button>
+  <sui-mixer-button (press)="player.setShuffle(false)">Shuffle Off</sui-mixer-button>
 </div>
 
 <h2 class="mt-5">2-Track USB Recorder</h2>
@@ -51,7 +51,7 @@
   <p><label>Busy</label> {{ rec.busy$ | async }}</p>
 </div>
 
-<sui-mixer-button (press)="rec.recordToggle()" [active]="!!(rec.recording$ | async)">
+<sui-mixer-button (press)="rec.recordToggle()" [active]="rec.recording$ | async">
   REC
 </sui-mixer-button>
 <sui-mixer-button (press)="rec.recordStart()">REC Start</sui-mixer-button>

--- a/packages/testbed/src/app/ui/mixer-button/mixer-button.ts
+++ b/packages/testbed/src/app/ui/mixer-button/mixer-button.ts
@@ -8,7 +8,7 @@ import { Component, computed, input, output } from '@angular/core';
 })
 export class MixerButton {
   readonly activeClass = input('default-active');
-  readonly active = input(false);
+  readonly active = input<boolean | null>(false);
   readonly press = output();
 
   readonly classDefinition = computed(() => {

--- a/packages/testbed/src/app/ui/mute-button/mute-button.html
+++ b/packages/testbed/src/app/ui/mute-button/mute-button.html
@@ -1,6 +1,6 @@
 <sui-mixer-button
   activeClass="mute"
-  [active]="!!(channel().mute$ | async)"
+  [active]="channel().mute$ | async"
   (press)="channel().toggleMute()"
 >
   Mute toggle {{ label() }}

--- a/packages/testbed/src/app/ui/postproc-controls/postproc-controls.ts
+++ b/packages/testbed/src/app/ui/postproc-controls/postproc-controls.ts
@@ -1,6 +1,6 @@
 import { toSignal, toObservable } from '@angular/core/rxjs-interop';
 import { Component, input } from '@angular/core';
-import { map, switchMap } from 'rxjs';
+import { switchMap } from 'rxjs';
 import { PostProcessableChannel } from 'soundcraft-ui-connection';
 import { MixerButton } from '../mixer-button/mixer-button';
 
@@ -13,10 +13,7 @@ export class PostprocControls {
   readonly channel = input.required<PostProcessableChannel>();
 
   readonly postProc = toSignal(
-    toObservable(this.channel).pipe(
-      switchMap(channel => channel.postProc$),
-      map(e => !!e),
-    ),
+    toObservable(this.channel).pipe(switchMap(channel => channel.postProc$)),
     { initialValue: false },
   );
 

--- a/packages/testbed/src/app/ui/prepost-controls/prepost-controls.html
+++ b/packages/testbed/src/app/ui/prepost-controls/prepost-controls.html
@@ -2,7 +2,7 @@
 <sui-mixer-button (press)="channel().pre()">PRE</sui-mixer-button>
 <sui-mixer-button
   activeClass="post"
-  [active]="!!(channel().post$ | async)"
+  [active]="channel().post$ | async"
   (press)="channel().togglePost()"
 >
   Toggle PRE/POST

--- a/packages/testbed/src/app/ui/prepost-controls/prepost-controls.ts
+++ b/packages/testbed/src/app/ui/prepost-controls/prepost-controls.ts
@@ -1,7 +1,7 @@
 import { AsyncPipe } from '@angular/common';
 import { toSignal, toObservable } from '@angular/core/rxjs-interop';
 import { Component, input } from '@angular/core';
-import { map, switchMap } from 'rxjs';
+import { switchMap } from 'rxjs';
 import { SendChannel } from 'soundcraft-ui-connection';
 import { MixerButton } from '../mixer-button/mixer-button';
 
@@ -14,11 +14,7 @@ import { MixerButton } from '../mixer-button/mixer-button';
 export class PrepostControls {
   readonly channel = input.required<SendChannel>();
 
-  readonly post = toSignal(
-    toObservable(this.channel).pipe(
-      switchMap(channel => channel.post$),
-      map(e => !!e)
-    ),
-    { initialValue: false }
-  );
+  readonly post = toSignal(toObservable(this.channel).pipe(switchMap(channel => channel.post$)), {
+    initialValue: false,
+  });
 }

--- a/packages/testbed/src/app/ui/solo-button/solo-button.html
+++ b/packages/testbed/src/app/ui/solo-button/solo-button.html
@@ -1,8 +1,4 @@
-<sui-mixer-button
-  activeClass="solo"
-  [active]="!!(channel().solo$ | async)"
-  (press)="channel().toggleSolo()"
->
+<sui-mixer-button activeClass="solo" [active]="channel().solo$ | async" (press)="channel().toggleSolo()">
   Solo toggle {{ label() }}
 </sui-mixer-button>
 <sui-mixer-button (press)="channel().solo()">Solo {{ label() }}</sui-mixer-button>

--- a/packages/testbed/src/app/ui/time.pipe.ts
+++ b/packages/testbed/src/app/ui/time.pipe.ts
@@ -1,12 +1,12 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { playerTimeToString } from 'soundcraft-ui-connection';
 
-@Pipe({
-  name: 'time',
-  standalone: true,
-})
+@Pipe({ name: 'time' })
 export class TimePipe implements PipeTransform {
-  transform(value: number): string {
+  transform(value: number | null): string {
+    if (value === null) {
+      return '';
+    }
     return playerTimeToString(value);
   }
 }


### PR DESCRIPTION
## Summary

Breaking change: every boolean-like on/off value is now a real `boolean` in the public API instead of the wire-protocol's numeric `0`/`1`.

### Read side
- Observables now emit `true`/`false`: `mute$`, `solo$`, `dim$`, `phantom$`, `post$`, `postProc$`, `multiTrackSelected$`, `shuffle$`, `recording$`, `busy$`, `soundcheck$`, automix `state$`, mute-group `state$` (`isMatrix$` was already boolean).
- New `selectBoolean()` operator (boolean analog of `selectRawValue`) for the raw-value cases; the predefined selectors (`selectMute`, `selectSolo`, `selectMasterDim`, `selectPhantom`, `selectPost`, `selectPostProc`, `selectMatrix`) now return `boolean`.
- `getValueOfBit()` now returns a `boolean` (and returns `false` for a negative bit index).

### Write side
- New `MixerConnection.setdBool(path, value)` builds the `SETD` message, converting the boolean to `0`/`1`.
- On/off setters now accept a `boolean`: `setMute`, `setSolo`, `setDim`, `setPhantom`, `setPost`, `setPostProc`, `setShuffle`, `setSoundcheck` (plus internal `setMatrixMode`, multitrack and automix helpers). Wrappers pass `true`/`false`; toggles use `!value`.

### Other
- Tests, testbed (`[active]` bindings, `setShuffle`) and docs updated.
- Added `setd()` / `sets()` / `setdBool()` helper tests and `selectBoolean` coverage.

## Notes
- Outbound wire format is unchanged (`SETD^…^0|1`); only the public TS API changed.
- Behavior change: selectors without a stored value now emit `false` immediately (e.g. `solo$`) instead of staying silent until the first message — consistent with `mute$`.

## Verification
`nx run-many -t test lint build` green for `mixer-connection` and `testbed`; `nx format:check` clean.

The first commit (`TimePipe` accepting `number | null`) is unrelated cleanup, kept separate.