### PR TITLE
refactor: pre-build linked channel arrays to avoid allocations on ope…

### DIFF
--- a/packages/mixer-connection/src/lib/facade/aux-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/aux-channel.ts
@@ -12,8 +12,8 @@ import { SendChannel } from './send-channel';
  * Represents a channel on an AUX bus
  */
 export class AuxChannel extends SendChannel implements PannableChannel, PostProcessableChannel {
-  /** when the AUX bus is stereo-linked, this contains the ID of this channel on the linked bus */
-  private auxLinkChannelIds: string[] = [];
+  /** when the AUX bus is stereo-linked, this also contains the ID of this channel on the linked bus */
+  private auxLinkChannelIds: string[] = [this.fullChannelId];
 
   /** PAN value of the AUX channel (between `0` and `1`) */
   readonly pan$ = this.store.state$.pipe(
@@ -46,8 +46,8 @@ export class AuxChannel extends SendChannel implements PannableChannel, PostProc
           const linkedAuxNo = getLinkedChannelNumber(bus, auxIndex);
           const linkedChNo = getLinkedChannelNumber(channel, channelIndex);
 
-          const allChannelIds = []; // all linked channels on this bus and on the linked bus
-          const auxLinkChannelIds = []; // this channel on the linked bus
+          const allChannelIds = [this.fullChannelId]; // all linked channels on this bus and on the linked bus
+          const auxLinkChannelIds = [this.fullChannelId]; // this channel on the linked bus
 
           // add linked channel on this bus
           if (linkedChNo !== undefined) {
@@ -84,7 +84,7 @@ export class AuxChannel extends SendChannel implements PannableChannel, PostProc
   setPan(value: number) {
     value = clamp(value, 0, 1);
     value = roundToThreeDecimals(value);
-    [...this.auxLinkChannelIds, this.fullChannelId].forEach(cid => {
+    this.auxLinkChannelIds.forEach(cid => {
       this.conn.setd(`${cid}.pan`, value);
     });
   }
@@ -103,7 +103,7 @@ export class AuxChannel extends SendChannel implements PannableChannel, PostProc
    * @param value POST PROC (`true`) or PRE PROC (`false`)
    */
   setPostProc(value: boolean) {
-    [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
+    this.linkedChannelIds.forEach(cid => {
       this.conn.setdBool(`${cid}.postproc`, value);
     });
   }

--- a/packages/mixer-connection/src/lib/facade/channel.ts
+++ b/packages/mixer-connection/src/lib/facade/channel.ts
@@ -31,7 +31,7 @@ import { joinStatePath } from '../utils/state-utils';
 export class Channel implements FadeableChannel {
   protected fullChannelId = `${this.channelType}.${this.channel - 1}`;
   protected faderLevelCommand = 'mix';
-  protected linkedChannelIds: string[] = [];
+  protected linkedChannelIds: string[] = [this.fullChannelId];
 
   private transitionSources$ = new Subject<TransitionSource>();
 
@@ -133,7 +133,7 @@ export class Channel implements FadeableChannel {
   }
 
   private setFaderLevelRaw(value: number) {
-    [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
+    this.linkedChannelIds.forEach(cid => {
       this.conn.setd(`${cid}.${this.faderLevelCommand}`, value);
     });
   }
@@ -171,7 +171,7 @@ export class Channel implements FadeableChannel {
    * @param value MUTE state
    */
   setMute(value: boolean) {
-    [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
+    this.linkedChannelIds.forEach(cid => {
       this.conn.setdBool(`${cid}.mute`, value);
     });
   }

--- a/packages/mixer-connection/src/lib/facade/fx-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/fx-channel.ts
@@ -27,10 +27,11 @@ export class FxChannel extends SendChannel {
           const linkedChannelNumber = getLinkedChannelNumber(channel, index);
           if (linkedChannelNumber !== undefined) {
             return [
+              this.fullChannelId,
               constructSendChannelId(this.channelType, linkedChannelNumber, this.busType, this.bus),
             ];
           } else {
-            return [];
+            return [this.fullChannelId];
           }
         }),
       )

--- a/packages/mixer-connection/src/lib/facade/master-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/master-channel.ts
@@ -67,6 +67,7 @@ export class MasterChannel extends Channel implements PannableChannel {
 
   constructor(conn: MixerConnection, store: MixerStore, channelType: ChannelType, channel: number) {
     super(conn, store, channelType, channel);
+    this.linkedChannelIds = [this.fullChannelId];
 
     // create list of channel IDs that are linked with this channel
     this.stereoIndex$
@@ -74,9 +75,12 @@ export class MasterChannel extends Channel implements PannableChannel {
         map(index => {
           const linkedChannelNumber = getLinkedChannelNumber(channel, index);
           if (linkedChannelNumber !== undefined) {
-            return [constructMasterChannelId(this.channelType, linkedChannelNumber)];
+            return [
+              this.fullChannelId,
+              constructMasterChannelId(this.channelType, linkedChannelNumber),
+            ];
           } else {
-            return [];
+            return [this.fullChannelId];
           }
         }),
       )
@@ -106,7 +110,7 @@ export class MasterChannel extends Channel implements PannableChannel {
    * @param value SOLO state
    */
   setSolo(value: boolean) {
-    [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
+    this.linkedChannelIds.forEach(cid => {
       this.conn.setdBool(`${cid}.solo`, value);
     });
   }
@@ -177,7 +181,7 @@ export class MasterChannel extends Channel implements PannableChannel {
         break;
     }
 
-    [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
+    this.linkedChannelIds.forEach(cid => {
       this.conn.setd(`${cid}.amixgroup`, groupValue);
     });
   }
@@ -194,7 +198,7 @@ export class MasterChannel extends Channel implements PannableChannel {
   automixSetWeight(value: number) {
     value = clamp(value, 0, 1);
 
-    [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
+    this.linkedChannelIds.forEach(cid => {
       this.conn.setd(`${cid}.amix`, value);
     });
   }

--- a/packages/mixer-connection/src/lib/facade/mtx-bus-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/mtx-bus-channel.ts
@@ -43,8 +43,8 @@ export class MtxBusChannel extends MtxChannel {
           const linkedMtxNo = getLinkedChannelNumber(bus, mtxIndex);
           const linkedChNo = getLinkedChannelNumber(channel, channelIndex);
 
-          const allChannelIds = []; // all linked channels on this matrix and on the linked matrix
-          const mtxLinkChannelIds = []; // this channel on the linked matrix output
+          const allChannelIds = [this.fullChannelId]; // all linked channels on this matrix and on the linked matrix
+          const mtxLinkChannelIds = [this.fullChannelId]; // this channel on the linked matrix output
 
           // add linked source channel on this matrix
           if (linkedChNo !== undefined) {

--- a/packages/mixer-connection/src/lib/facade/mtx-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/mtx-channel.ts
@@ -45,10 +45,10 @@ export abstract class MtxChannel
   readonly postProc$ = this.store.state$.pipe(selectBoolean(`${this.fullChannelId}.postproc`));
 
   /** all linked channels (mirror on the stereo-linked matrix output and stereo-link neighbour) */
-  protected linkedChannelIds: string[] = [];
+  protected linkedChannelIds: string[] = [this.fullChannelId];
 
   /** channels that mirror the PAN value (the stereo-linked matrix output, but not a neighbour source) */
-  protected panLinkChannelIds: string[] = [];
+  protected panLinkChannelIds: string[] = [this.fullChannelId];
 
   private transitionSources$ = new Subject<TransitionSource>();
 
@@ -98,7 +98,7 @@ export abstract class MtxChannel
   }
 
   private setFaderLevelRaw(value: number) {
-    [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
+    this.linkedChannelIds.forEach(cid => {
       this.conn.setd(`${cid}.value`, value);
     });
   }
@@ -136,7 +136,7 @@ export abstract class MtxChannel
    * @param value MUTE state
    */
   setMute(value: boolean) {
-    [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
+    this.linkedChannelIds.forEach(cid => {
       this.conn.setdBool(`${cid}.mute`, value);
     });
   }
@@ -164,7 +164,7 @@ export abstract class MtxChannel
   setPan(value: number) {
     value = clamp(value, 0, 1);
     value = roundToThreeDecimals(value);
-    [...this.panLinkChannelIds, this.fullChannelId].forEach(cid => {
+    this.panLinkChannelIds.forEach(cid => {
       this.conn.setd(`${cid}.pan`, value);
     });
   }
@@ -183,7 +183,7 @@ export abstract class MtxChannel
    * @param value POST PROC (`true`) or PRE PROC (`false`)
    */
   setPostProc(value: boolean) {
-    [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
+    this.linkedChannelIds.forEach(cid => {
       this.conn.setdBool(`${cid}.postproc`, value);
     });
   }

--- a/packages/mixer-connection/src/lib/facade/mtx-master-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/mtx-master-channel.ts
@@ -26,12 +26,14 @@ export class MtxMasterChannel extends MtxChannel {
         select(selectStereoIndex('a', bus)),
         map(mtxIndex => {
           const linkedMtxNo = getLinkedChannelNumber(bus, mtxIndex);
-          return linkedMtxNo !== undefined ? [`m.mtx.${linkedMtxNo - 1}`] : [];
+          return linkedMtxNo !== undefined
+            ? [this.fullChannelId, `m.mtx.${linkedMtxNo - 1}`]
+            : [this.fullChannelId];
         }),
       )
-      .subscribe(mirror => {
-        this.linkedChannelIds = mirror;
-        this.panLinkChannelIds = mirror;
+      .subscribe(linkedChannels => {
+        this.linkedChannelIds = linkedChannels;
+        this.panLinkChannelIds = linkedChannels;
       });
   }
 }

--- a/packages/mixer-connection/src/lib/facade/send-channel.ts
+++ b/packages/mixer-connection/src/lib/facade/send-channel.ts
@@ -34,6 +34,7 @@ export class SendChannel extends Channel {
     bus: number,
   ) {
     super(conn, store, channelType, channel, busType, bus);
+    this.linkedChannelIds = [this.fullChannelId];
   }
 
   /**
@@ -41,7 +42,7 @@ export class SendChannel extends Channel {
    * @param value POST (`true`) or PRE (`false`)
    */
   setPost(value: boolean) {
-    [...this.linkedChannelIds, this.fullChannelId].forEach(cid => {
+    this.linkedChannelIds.forEach(cid => {
       this.conn.setdBool(`${cid}.post`, value);
     });
   }

--- a/packages/mixer-connection/src/lib/facade/stereo-link.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/stereo-link.spec.ts
@@ -29,23 +29,23 @@ describe('Stereo linking', () => {
 
       let messages = collectMessages(conn);
       channel.setFaderLevel(0.5);
-      expect(messages).toEqual(['SETD^i.3.mix^0.5', 'SETD^i.2.mix^0.5']);
+      expect(messages).toEqual(['SETD^i.2.mix^0.5', 'SETD^i.3.mix^0.5']);
 
       messages = collectMessages(conn);
       channel.setMute(true);
-      expect(messages).toEqual(['SETD^i.3.mute^1', 'SETD^i.2.mute^1']);
+      expect(messages).toEqual(['SETD^i.2.mute^1', 'SETD^i.3.mute^1']);
 
       messages = collectMessages(conn);
       channel.setSolo(true);
-      expect(messages).toEqual(['SETD^i.3.solo^1', 'SETD^i.2.solo^1']);
+      expect(messages).toEqual(['SETD^i.2.solo^1', 'SETD^i.3.solo^1']);
 
       messages = collectMessages(conn);
       channel.automixAssignGroup('a');
-      expect(messages).toEqual(['SETD^i.3.amixgroup^0', 'SETD^i.2.amixgroup^0']);
+      expect(messages).toEqual(['SETD^i.2.amixgroup^0', 'SETD^i.3.amixgroup^0']);
 
       messages = collectMessages(conn);
       channel.automixSetWeight(0.5);
-      expect(messages).toEqual(['SETD^i.3.amix^0.5', 'SETD^i.2.amix^0.5']);
+      expect(messages).toEqual(['SETD^i.2.amix^0.5', 'SETD^i.3.amix^0.5']);
     });
 
     it('should mirror commands to the linked neighbour (second in link)', () => {
@@ -55,7 +55,7 @@ describe('Stereo linking', () => {
 
       const messages = collectMessages(conn);
       channel.setFaderLevel(0.5);
-      expect(messages).toEqual(['SETD^i.2.mix^0.5', 'SETD^i.3.mix^0.5']);
+      expect(messages).toEqual(['SETD^i.3.mix^0.5', 'SETD^i.2.mix^0.5']);
     });
 
     it('should NOT mirror PAN (it is the only per-channel setting)', () => {
@@ -84,11 +84,11 @@ describe('Stereo linking', () => {
 
       let messages = collectMessages(conn);
       conn.master.line(1).setFaderLevel(0.5);
-      expect(messages).toEqual(['SETD^l.1.mix^0.5', 'SETD^l.0.mix^0.5']);
+      expect(messages).toEqual(['SETD^l.0.mix^0.5', 'SETD^l.1.mix^0.5']);
 
       messages = collectMessages(conn);
       conn.master.player(1).setMute(true);
-      expect(messages).toEqual(['SETD^p.1.mute^1', 'SETD^p.0.mute^1']);
+      expect(messages).toEqual(['SETD^p.0.mute^1', 'SETD^p.1.mute^1']);
     });
   });
 
@@ -104,19 +104,19 @@ describe('Stereo linking', () => {
 
       let messages = collectMessages(conn);
       channel.setFaderLevel(0.5);
-      expect(messages).toEqual(['SETD^i.3.aux.1.value^0.5', 'SETD^i.2.aux.1.value^0.5']);
+      expect(messages).toEqual(['SETD^i.2.aux.1.value^0.5', 'SETD^i.3.aux.1.value^0.5']);
 
       messages = collectMessages(conn);
       channel.setMute(true);
-      expect(messages).toEqual(['SETD^i.3.aux.1.mute^1', 'SETD^i.2.aux.1.mute^1']);
+      expect(messages).toEqual(['SETD^i.2.aux.1.mute^1', 'SETD^i.3.aux.1.mute^1']);
 
       messages = collectMessages(conn);
       channel.setPost(true);
-      expect(messages).toEqual(['SETD^i.3.aux.1.post^1', 'SETD^i.2.aux.1.post^1']);
+      expect(messages).toEqual(['SETD^i.2.aux.1.post^1', 'SETD^i.3.aux.1.post^1']);
 
       messages = collectMessages(conn);
       channel.setPostProc(true);
-      expect(messages).toEqual(['SETD^i.3.aux.1.postproc^1', 'SETD^i.2.aux.1.postproc^1']);
+      expect(messages).toEqual(['SETD^i.2.aux.1.postproc^1', 'SETD^i.3.aux.1.postproc^1']);
     });
   });
 
@@ -132,7 +132,7 @@ describe('Stereo linking', () => {
 
       const messages = collectMessages(conn);
       channel.setFaderLevel(0.5);
-      expect(messages).toEqual(['SETD^i.2.aux.1.value^0.5', 'SETD^i.2.aux.0.value^0.5']);
+      expect(messages).toEqual(['SETD^i.2.aux.0.value^0.5', 'SETD^i.2.aux.1.value^0.5']);
     });
 
     it('should mirror PAN to this channel on the linked bus', () => {
@@ -140,7 +140,7 @@ describe('Stereo linking', () => {
 
       const messages = collectMessages(conn);
       channel.setPan(0.5);
-      expect(messages).toEqual(['SETD^i.2.aux.1.pan^0.5', 'SETD^i.2.aux.0.pan^0.5']);
+      expect(messages).toEqual(['SETD^i.2.aux.0.pan^0.5', 'SETD^i.2.aux.1.pan^0.5']);
     });
   });
 
@@ -157,10 +157,10 @@ describe('Stereo linking', () => {
       const messages = collectMessages(conn);
       channel.setFaderLevel(0.5);
       expect(messages).toEqual([
+        'SETD^i.2.aux.0.value^0.5', // self
         'SETD^i.3.aux.0.value^0.5', // neighbour on this bus
         'SETD^i.2.aux.1.value^0.5', // this channel on the linked bus
         'SETD^i.3.aux.1.value^0.5', // neighbour on the linked bus
-        'SETD^i.2.aux.0.value^0.5', // self
       ]);
     });
 
@@ -170,10 +170,10 @@ describe('Stereo linking', () => {
       const messages = collectMessages(conn);
       channel.setMute(true);
       expect(messages).toEqual([
+        'SETD^i.2.aux.0.mute^1',
         'SETD^i.3.aux.0.mute^1',
         'SETD^i.2.aux.1.mute^1',
         'SETD^i.3.aux.1.mute^1',
-        'SETD^i.2.aux.0.mute^1',
       ]);
     });
 
@@ -183,10 +183,10 @@ describe('Stereo linking', () => {
       const messages = collectMessages(conn);
       channel.setPost(true);
       expect(messages).toEqual([
+        'SETD^i.2.aux.0.post^1',
         'SETD^i.3.aux.0.post^1',
         'SETD^i.2.aux.1.post^1',
         'SETD^i.3.aux.1.post^1',
-        'SETD^i.2.aux.0.post^1',
       ]);
     });
 
@@ -196,10 +196,10 @@ describe('Stereo linking', () => {
       const messages = collectMessages(conn);
       channel.setPostProc(true);
       expect(messages).toEqual([
+        'SETD^i.2.aux.0.postproc^1',
         'SETD^i.3.aux.0.postproc^1',
         'SETD^i.2.aux.1.postproc^1',
         'SETD^i.3.aux.1.postproc^1',
-        'SETD^i.2.aux.0.postproc^1',
       ]);
     });
 
@@ -208,7 +208,7 @@ describe('Stereo linking', () => {
 
       const messages = collectMessages(conn);
       channel.setPan(0.5);
-      expect(messages).toEqual(['SETD^i.2.aux.1.pan^0.5', 'SETD^i.2.aux.0.pan^0.5']);
+      expect(messages).toEqual(['SETD^i.2.aux.0.pan^0.5', 'SETD^i.2.aux.1.pan^0.5']);
     });
   });
 
@@ -222,10 +222,10 @@ describe('Stereo linking', () => {
       const messages = collectMessages(conn);
       channel.setMute(true);
       expect(messages).toEqual([
+        'SETD^i.3.aux.1.mute^1', // self
         'SETD^i.2.aux.1.mute^1', // neighbour on this bus
         'SETD^i.3.aux.0.mute^1', // this channel on the linked bus
         'SETD^i.2.aux.0.mute^1', // neighbour on the linked bus
-        'SETD^i.3.aux.1.mute^1', // self
       ]);
     });
   });


### PR DESCRIPTION
…ration

- Initialize `linkedChannelIds` (as well as `auxLinkChannelIds` and `panLinkChannelIds`) with `this.fullChannelId` upon channel creation
- Construct complete channel linking arrays directly inside RxJS `map` operators prior to `subscribe` callbacks
- Iterate directly over pre-built linking arrays in facade operations (`setFaderLevelRaw`, `setMute`, `setPan`, `setSolo`, `setPost`, `setPostProc`, automix commands) instead of spreading `[...linked, self]` on every invocation
- Update stereo linking test expectations to reflect self-channel commands executing first