### PR TITLE
feat: expose playlists, shows, snapshots and cues

### DIFF
--- a/docs/docs/features/shows.md
+++ b/docs/docs/features/shows.md
@@ -15,6 +15,7 @@ The `ShowController` object is available in `conn.shows` and supports these oper
 | `currentShow$`                         | Currently loaded show                                                |
 | `currentSnapshot$`                     | Currently loaded snapshot                                            |
 | `currentCue$`                          | Currently loaded cue                                                 |
+| `shows$`                               | All shows with their snapshots and cues (see below)                  |
 | `loadShow(showName)`                   | Load a show by its name                                              |
 | `loadSnapshot(showName, snapshotName)` | Load a snapshot in a show by its name                                |
 | `loadCue(showName, cueName)`           | Load a cue in a show by its name                                     |
@@ -22,8 +23,23 @@ The `ShowController` object is available in `conn.shows` and supports these oper
 | `saveCue(showName, cueName)`           | Save a cue in a show. This will overwrite an existing cue.           |
 | `updateCurrentSnapshot()`              | Update/overwrite the currently loaded snapshot                       |
 | `updateCurrentCue()`                   | Update/overwrite the currently loaded cue                            |
+| `refreshShows()`                       | Request the current shows and their snapshots/cues from the mixer    |
 
 Please be aware that no confirmation is required when snapshots or cues are saved. Be careful not to overwrite existing parts by accident.
+
+## Listing shows, snapshots and cues
+
+Unlike fader levels or mute states, the available shows and their snapshots/cues are **not** part of the global mixer state. The mixer sends this information per-client and only on request. The library requests it automatically whenever the connection is (re-)established, so `shows$` emits as soon as the data arrives. Call `refreshShows()` to refresh it manually.
+
+`shows$` emits a map of show name to its snapshots and cues. As snapshots and cues are not hierarchical, they are listed side by side for each show:
+
+```ts
+conn.shows.shows$.subscribe(shows => console.log(shows));
+// {
+//   Default: { snapshots: ['* Init *', 'snap2'], cues: ['test'] },
+//   testshow: { snapshots: [], cues: [] }
+// }
+```
 
 :::info
 

--- a/docs/docs/recording-playback/media-player.md
+++ b/docs/docs/recording-playback/media-player.md
@@ -15,6 +15,8 @@ The Media Player can be accessed through `conn.player`. This object exposes the 
 | `elapsedTime$`               | Elapsed time of current track in seconds                                                                     |
 | `remainingTime$`             | Remaining time of current track in seconds                                                                   |
 | `shuffle$`                   | Shuffle state                                                                                                |
+| `playlists$`                 | Names of all available playlists                                                                             |
+| `playlistsWithTracks$`       | All playlists with their tracks as a map of playlist name to track names                                     |
 | `play()`                     | Play                                                                                                         |
 | `pause()`                    | Pause                                                                                                        |
 | `stop()`                     | Stop                                                                                                         |
@@ -27,3 +29,12 @@ The Media Player can be accessed through `conn.player`. This object exposes the 
 | `setPlayMode(value)`         | Set player mode like `manual` or `auto`. Values are rather internal, please use convenience functions below. |
 | `setManual()`                | Enable manual mode                                                                                           |
 | `setAuto()`                  | Enable automatic                                                                                             |
+| `refreshPlaylists()`         | Request the current playlists and their tracks from the mixer                                                |
+
+## Playlists
+
+Unlike fader levels or mute states, the available playlists and their tracks are **not** part of
+the global mixer state. The mixer sends this information per-client and only on request. The
+library requests it automatically whenever the connection is (re-)established, so `playlists$` and
+`playlistsWithTracks$` emit as soon as the data arrives. Call `refreshPlaylists()` to refresh it
+manually, e.g. after playlists have been added or removed on the device.

--- a/packages/mixer-connection/src/lib/__tests__/outbound-messages.spec.ts
+++ b/packages/mixer-connection/src/lib/__tests__/outbound-messages.spec.ts
@@ -1102,6 +1102,9 @@ describe('Outbound messages', () => {
 
     conn.player.setAuto();
     expect(message).toBe('SETD^settings.playMode^3');
+
+    conn.player.refreshPlaylists();
+    expect(message).toBe('MEDIA_GET_PLISTS');
   });
 
   it('2-track recorder', () => {
@@ -1178,6 +1181,9 @@ describe('Outbound messages', () => {
 
     conn.shows.saveCue('testshow', 'testcue');
     expect(message).toBe('SAVECUE^testshow^testcue');
+
+    conn.shows.refreshShows();
+    expect(message).toBe('SHOWLIST');
   });
 
   it('automix controller', () => {

--- a/packages/mixer-connection/src/lib/facade/player.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/player.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { firstValueFrom } from 'rxjs';
 import { SoundcraftUI } from '../soundcraft-ui';
 import { PlayerState } from '../types';
+import { MockWebSocket } from '../utils/mock-websocket';
 import { Player } from './player';
 
 describe('Player', () => {
@@ -49,6 +50,74 @@ describe('Player', () => {
     conn.conn.sendMessage('SETD^var.currentLength^130');
     conn.conn.sendMessage('SETD^var.currentTrackPos^0.6'); // between 0 and 1
     expect(await firstValueFrom(player.remainingTime$)).toBe(52);
+  });
+
+  describe('Playlists', () => {
+    let socket: MockWebSocket;
+    let mixer: SoundcraftUI;
+    let outbound: string[];
+
+    /** outbound messages that belong to the playlist feature (ignores other facades and keepalive) */
+    const playlistOutbound = () =>
+      outbound.filter(msg =>
+        ['MEDIA_GET_PLISTS', 'MEDIA_GET_PLIST_TRACKS'].includes(msg.split('^')[0]),
+      );
+
+    beforeEach(async () => {
+      mixer = new SoundcraftUI({
+        targetIP: '0.0.0.0',
+        webSocketCtor: MockWebSocket.withCapture(
+          instance => (socket = instance),
+        ) as unknown as typeof WebSocket,
+      });
+      outbound = [];
+      mixer.conn.outbound$.subscribe(msg => outbound.push(msg));
+
+      const connected = mixer.conn.connect();
+      socket.simulateOpen();
+      await connected;
+    });
+
+    it('fetches playlists automatically on connection open', () => {
+      expect(playlistOutbound()).toEqual(['MEDIA_GET_PLISTS']);
+    });
+
+    it('requests tracks for each playlist after the PLISTS reply', () => {
+      socket.simulateMessage('3:::PLISTS^List1^List2^~all~');
+      expect(playlistOutbound()).toEqual([
+        'MEDIA_GET_PLISTS',
+        'MEDIA_GET_PLIST_TRACKS^List1',
+        'MEDIA_GET_PLIST_TRACKS^List2',
+        'MEDIA_GET_PLIST_TRACKS^~all~',
+      ]);
+    });
+
+    it('playlists$', async () => {
+      socket.simulateMessage('3:::PLISTS^List1^List2^~all~');
+      expect(await firstValueFrom(mixer.player.playlists$)).toEqual(['List1', 'List2', '~all~']);
+    });
+
+    it('playlistsWithTracks$', async () => {
+      socket.simulateMessage('3:::PLISTS^List1^List2^~all~');
+      socket.simulateMessage('3:::PLIST_TRACKS^List1^a.mp3^b.mp3');
+      expect(await firstValueFrom(mixer.player.playlistsWithTracks$)).toEqual({
+        List1: ['a.mp3', 'b.mp3'],
+        List2: [],
+        '~all~': [],
+      });
+    });
+
+    it('prunes removed playlists when a new PLISTS arrives', async () => {
+      socket.simulateMessage('3:::PLISTS^List1^List2');
+      socket.simulateMessage('3:::PLIST_TRACKS^List1^a.mp3');
+      socket.simulateMessage('3:::PLIST_TRACKS^List2^c.mp3');
+
+      // List2 is gone now
+      socket.simulateMessage('3:::PLISTS^List1');
+      expect(await firstValueFrom(mixer.player.playlistsWithTracks$)).toEqual({
+        List1: ['a.mp3'],
+      });
+    });
   });
 
   describe('Shuffle', () => {

--- a/packages/mixer-connection/src/lib/facade/player.ts
+++ b/packages/mixer-connection/src/lib/facade/player.ts
@@ -1,7 +1,8 @@
-import { take } from 'rxjs';
+import { distinctUntilChanged, filter, map, take } from 'rxjs';
 
 import { MixerConnection } from '../mixer-connection';
 import { MixerStore } from '../state/mixer-store';
+import { PLAYLISTS_KEY, PLAYLIST_TRACKS_KEY, requestResourceList } from '../state/resource-lists';
 import {
   select,
   selectBoolean,
@@ -10,7 +11,7 @@ import {
   selectPlayerRemainingTime,
   selectRawValue,
 } from '../state/state-selectors';
-import { PlayerState } from '../types';
+import { ConnectionStatus, PlayerState, PlaylistsWithTracks } from '../types';
 
 /**
  * Represents the media player
@@ -39,10 +40,37 @@ export class Player {
   /** Shuffle state */
   readonly shuffle$ = this.store.state$.pipe(selectBoolean('settings.shuffle'));
 
+  /**
+   * All available playlists with their tracks (playlist name -> track names).
+   * Fetched on connect; refresh manually with {@link refreshPlaylists}.
+   */
+  readonly playlistsWithTracks$ = this.store.resourceListState$.pipe(
+    map((state): PlaylistsWithTracks => {
+      const names = state[PLAYLISTS_KEY] ?? [];
+      return Object.fromEntries(
+        names.map(name => [name, state[`${PLAYLIST_TRACKS_KEY}^${name}`] ?? []]),
+      );
+    }),
+  );
+
+  /**
+   * Names of all available playlists.
+   * Fetched on connect; refresh manually with {@link refreshPlaylists}.
+   */
+  readonly playlists$ = this.store.resourceListState$.pipe(
+    map(state => state[PLAYLISTS_KEY] ?? []),
+    distinctUntilChanged((a, b) => a.length === b.length && a.every((value, i) => value === b[i])),
+  );
+
   constructor(
     private conn: MixerConnection,
     private store: MixerStore,
-  ) {}
+  ) {
+    // playlists are sent per-client on request, so (re-)fetch them on every connection open
+    this.conn.status$
+      .pipe(filter(e => e.type === ConnectionStatus.Open))
+      .subscribe(() => this.refreshPlaylists());
+  }
 
   /** Start the media player */
   play() {
@@ -118,5 +146,16 @@ export class Player {
   /** Enable automatic mode */
   setAuto() {
     this.setPlayMode(3);
+  }
+
+  /**
+   * Request the list of playlists and their tracks from the mixer.
+   * Results are exposed through {@link playlists$} and {@link playlistsWithTracks$}.
+   * This is called automatically on every connection open.
+   */
+  refreshPlaylists() {
+    requestResourceList(this.conn, 'MEDIA_GET_PLISTS', 'PLISTS').subscribe(playlists =>
+      playlists.forEach(name => this.conn.sendMessage(`MEDIA_GET_PLIST_TRACKS^${name}`)),
+    );
   }
 }

--- a/packages/mixer-connection/src/lib/facade/show-controller.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/show-controller.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { firstValueFrom } from 'rxjs';
 import { SoundcraftUI } from '../soundcraft-ui';
+import { MockWebSocket } from '../utils/mock-websocket';
 
 describe('Show Controller', () => {
   let conn: SoundcraftUI;
@@ -22,6 +23,75 @@ describe('Show Controller', () => {
   it('currentCue$', async () => {
     conn.conn.sendMessage('SETS^var.currentCue^THECUE');
     expect(await firstValueFrom(conn.shows.currentCue$)).toBe('THECUE');
+  });
+
+  describe('Shows listing', () => {
+    let socket: MockWebSocket;
+    let mixer: SoundcraftUI;
+    let outbound: string[];
+
+    /** outbound messages that belong to the show listing feature (ignores other facades and keepalive) */
+    const showOutbound = () =>
+      outbound.filter(msg => ['SHOWLIST', 'SNAPSHOTLIST', 'CUELIST'].includes(msg.split('^')[0]));
+
+    beforeEach(async () => {
+      mixer = new SoundcraftUI({
+        targetIP: '0.0.0.0',
+        webSocketCtor: MockWebSocket.withCapture(
+          instance => (socket = instance),
+        ) as unknown as typeof WebSocket,
+      });
+      outbound = [];
+      mixer.conn.outbound$.subscribe(msg => outbound.push(msg));
+
+      const connected = mixer.conn.connect();
+      socket.simulateOpen();
+      await connected;
+    });
+
+    it('fetches shows automatically on connection open', () => {
+      expect(showOutbound()).toEqual(['SHOWLIST']);
+    });
+
+    it('requests snapshots and cues for each show after the SHOWLIST reply', () => {
+      socket.simulateMessage('3:::SHOWLIST^Default^test');
+      expect(showOutbound()).toEqual([
+        'SHOWLIST',
+        'SNAPSHOTLIST^Default',
+        'CUELIST^Default',
+        'SNAPSHOTLIST^test',
+        'CUELIST^test',
+      ]);
+    });
+
+    it('shows$', async () => {
+      socket.simulateMessage('3:::SHOWLIST^Default^test');
+      socket.simulateMessage('3:::SNAPSHOTLIST^Default^snap1^snap2');
+      socket.simulateMessage('3:::CUELIST^Default^cue1');
+      expect(await firstValueFrom(mixer.shows.shows$)).toEqual({
+        Default: { snapshots: ['snap1', 'snap2'], cues: ['cue1'] },
+        test: { snapshots: [], cues: [] },
+      });
+    });
+
+    it('treats an empty cue list (trailing separator) as no cues', async () => {
+      socket.simulateMessage('3:::SHOWLIST^Default');
+      socket.simulateMessage('3:::CUELIST^Default^');
+      expect(await firstValueFrom(mixer.shows.shows$)).toEqual({
+        Default: { snapshots: [], cues: [] },
+      });
+    });
+
+    it('prunes removed shows when a new SHOWLIST arrives', async () => {
+      socket.simulateMessage('3:::SHOWLIST^Default^test');
+      socket.simulateMessage('3:::SNAPSHOTLIST^Default^snap1');
+
+      // test is gone now
+      socket.simulateMessage('3:::SHOWLIST^Default');
+      expect(await firstValueFrom(mixer.shows.shows$)).toEqual({
+        Default: { snapshots: ['snap1'], cues: [] },
+      });
+    });
   });
 
   describe('updateCurrentSnapshot', () => {

--- a/packages/mixer-connection/src/lib/facade/show-controller.ts
+++ b/packages/mixer-connection/src/lib/facade/show-controller.ts
@@ -1,7 +1,9 @@
-import { combineLatest, filter, take } from 'rxjs';
+import { combineLatest, filter, map, take } from 'rxjs';
 import { MixerConnection } from '../mixer-connection';
 import { MixerStore } from '../state/mixer-store';
+import { CUES_KEY, requestResourceList, SHOWS_KEY, SNAPSHOTS_KEY } from '../state/resource-lists';
 import { selectRawValue } from '../state/state-selectors';
+import { ConnectionStatus, ShowsWithDetails } from '../types';
 
 /**
  * Controller for Shows, Snapshots and Cues
@@ -16,10 +18,35 @@ export class ShowController {
   /** Currently loaded cue */
   readonly currentCue$ = this.store.state$.pipe(selectRawValue<string>('var.currentCue'));
 
+  /**
+   * All available shows with their snapshots and cues (show name -> { snapshots, cues }).
+   * Snapshots and cues are not hierarchical; both hang off a show in parallel.
+   * Fetched on connect; refresh manually with {@link refreshShows}.
+   */
+  readonly shows$ = this.store.resourceListState$.pipe(
+    map((state): ShowsWithDetails => {
+      const names = state[SHOWS_KEY] ?? [];
+      return Object.fromEntries(
+        names.map(name => [
+          name,
+          {
+            snapshots: state[`${SNAPSHOTS_KEY}^${name}`] ?? [],
+            cues: state[`${CUES_KEY}^${name}`] ?? [],
+          },
+        ]),
+      );
+    }),
+  );
+
   constructor(
     private conn: MixerConnection,
     private store: MixerStore,
-  ) {}
+  ) {
+    // shows/snapshots/cues are sent per-client on request, so (re-)fetch them on every open
+    this.conn.status$
+      .pipe(filter(e => e.type === ConnectionStatus.Open))
+      .subscribe(() => this.refreshShows());
+  }
 
   /**
    * Load a show by name
@@ -83,5 +110,19 @@ export class ShowController {
         filter(([show, cue]) => !!show && !!cue),
       )
       .subscribe(([show, cue]) => this.saveCue(show, cue));
+  }
+
+  /**
+   * Request the list of shows and, for each show, its snapshots and cues from the mixer.
+   * Results are exposed through {@link shows$}.
+   * This is called automatically on every connection open.
+   */
+  refreshShows() {
+    requestResourceList(this.conn, 'SHOWLIST', 'SHOWLIST').subscribe(shows =>
+      shows.forEach(show => {
+        this.conn.sendMessage(`SNAPSHOTLIST^${show}`);
+        this.conn.sendMessage(`CUELIST^${show}`);
+      }),
+    );
   }
 }

--- a/packages/mixer-connection/src/lib/state/mixer-store.spec.ts
+++ b/packages/mixer-connection/src/lib/state/mixer-store.spec.ts
@@ -4,16 +4,21 @@ import { MixerConnection } from '../mixer-connection';
 import { MixerStore } from './mixer-store';
 
 describe('Mixer Store', () => {
-  let conn: { allMessages$: Subject<string> };
+  let conn: { allMessages$: Subject<string>; inbound$: Subject<string> };
   let mixerStore: MixerStore;
 
   function sendMessage(message: string): void {
     conn.allMessages$.next(message);
   }
 
+  function sendInbound(message: string): void {
+    conn.inbound$.next(message);
+  }
+
   beforeEach(() => {
     conn = {
       allMessages$: new Subject<string>(),
+      inbound$: new Subject<string>(),
     };
 
     mixerStore = new MixerStore(conn as unknown as MixerConnection);
@@ -94,6 +99,54 @@ describe('Mixer Store', () => {
       sendMessage('FOO^bar^baz');
       sendMessage('XYZ^xyz^xyz');
       expect(await firstValueFrom(mixerStore.state$)).toEqual({ abc: 1, def: 'ghi' });
+    });
+  });
+
+  describe('resourceListState$', () => {
+    it('stores flat lists under the command and keyed lists under command^key', async () => {
+      sendInbound('PLISTS^List1^List2^~all~');
+      sendInbound('PLIST_TRACKS^List1^a.mp3^b.mp3');
+      expect(await firstValueFrom(mixerStore.resourceListState$)).toEqual({
+        PLISTS: ['List1', 'List2', '~all~'],
+        'PLIST_TRACKS^List1': ['a.mp3', 'b.mp3'],
+      });
+    });
+
+    it('replaces a flat list when it is sent again', async () => {
+      sendInbound('PLISTS^List1^List2');
+      sendInbound('PLISTS^List1');
+      expect(await firstValueFrom(mixerStore.resourceListState$)).toEqual({
+        PLISTS: ['List1'],
+      });
+    });
+
+    it('treats a trailing-separator list as empty (e.g. `PLIST_TRACKS^List1^`)', async () => {
+      sendInbound('PLISTS^List1');
+      sendInbound('PLIST_TRACKS^List1^');
+      expect(await firstValueFrom(mixerStore.resourceListState$)).toEqual({
+        PLISTS: ['List1'],
+        'PLIST_TRACKS^List1': [],
+      });
+    });
+
+    it('stores shows, snapshots and cues under their addresses', async () => {
+      sendInbound('SHOWLIST^Default^test');
+      sendInbound('SNAPSHOTLIST^Default^snap1^snap2');
+      sendInbound('CUELIST^Default^cue1');
+      expect(await firstValueFrom(mixerStore.resourceListState$)).toEqual({
+        SHOWLIST: ['Default', 'test'],
+        'SNAPSHOTLIST^Default': ['snap1', 'snap2'],
+        'CUELIST^Default': ['cue1'],
+      });
+    });
+
+    it('ignores messages that are not configured resource lists', async () => {
+      sendInbound('SETD^i.3.mute^1');
+      sendInbound('FOO^bar');
+      sendInbound('PLISTS^List1');
+      expect(await firstValueFrom(mixerStore.resourceListState$)).toEqual({
+        PLISTS: ['List1'],
+      });
     });
   });
 });

--- a/packages/mixer-connection/src/lib/state/mixer-store.ts
+++ b/packages/mixer-connection/src/lib/state/mixer-store.ts
@@ -2,6 +2,7 @@ import { connectable, filter, map, ReplaySubject, scan, share } from 'rxjs';
 
 import { MixerConnection } from '../mixer-connection';
 import { ObjectStore } from './object-store';
+import { RESOURCE_LIST_CONFIG } from './resource-lists';
 
 export class MixerStore {
   /** Stream of raw SETD and SETS messages */
@@ -51,11 +52,37 @@ export class MixerStore {
     { connector: () => new ReplaySubject(1) },
   );
 
+  /**
+   * Stream of per-client resource listings (playlists, and later shows/snapshots/cues).
+   * These are not part of the global SETD/SETS state; they are sent only on request.
+   * Each message is stored under its "address" (everything before the entries), see
+   * {@link RESOURCE_LIST_CONFIG}. Scans `inbound$` only, so our own outbound requests
+   * (whose command can equal the reply command, e.g. `SHOWLIST`) do not pollute the state.
+   */
+  readonly resourceListState$ = connectable(
+    this.conn.inbound$.pipe(
+      map(msg => msg.split('^')),
+      filter(parts => parts[0] in RESOURCE_LIST_CONFIG),
+      scan(
+        (acc, parts) => {
+          const addrLen = RESOURCE_LIST_CONFIG[parts[0]].keyed ? 2 : 1;
+          const address = parts.slice(0, addrLen).join('^');
+          // empty lists are sent with a trailing separator (e.g. `CUELIST^Default^`),
+          // which yields a single empty-string entry — drop it
+          return { ...acc, [address]: parts.slice(addrLen).filter(Boolean) };
+        },
+        {} as Record<string, string[]>,
+      ),
+    ),
+    { connector: () => new ReplaySubject(1) },
+  );
+
   readonly objectStore = new ObjectStore();
 
   constructor(private conn: MixerConnection) {
     // start producing state values
     this.state$.connect();
     this.syncState$.connect();
+    this.resourceListState$.connect();
   }
 }

--- a/packages/mixer-connection/src/lib/state/resource-lists.ts
+++ b/packages/mixer-connection/src/lib/state/resource-lists.ts
@@ -1,0 +1,59 @@
+import { Observable, filter, map, take } from 'rxjs';
+
+import { MixerConnection } from '../mixer-connection';
+
+/**
+ * Per-client resource listings (playlists, shows, snapshots, cues) are not part of the
+ * global SETD/SETS mixer state. They are sent only on request, via dedicated list messages.
+ *
+ * This config maps each reply command to whether it is keyed by a parent:
+ * - flat list `CMD^entry^entry…`            (`keyed: false`, e.g. `PLISTS`, `SHOWLIST`)
+ * - keyed list `CMD^key^entry^entry…`       (`keyed: true`, e.g. `PLIST_TRACKS`, `SNAPSHOTLIST`,
+ *   `CUELIST`), where `key` is the parent (playlist/show)
+ *
+ * The store stores each message under its "address" (the command plus its key, i.e. everything
+ * before the entries): 1 leading part for flat lists, 2 for keyed lists.
+ *
+ * An empty list is sent with a trailing separator and no entries (e.g. `CUELIST^Default^`),
+ * which splits into a single empty-string entry — so empty entries are filtered out on parsing.
+ */
+export const RESOURCE_LIST_CONFIG: Record<string, { keyed: boolean }> = {
+  PLISTS: { keyed: false },
+  PLIST_TRACKS: { keyed: true },
+  SHOWLIST: { keyed: false },
+  SNAPSHOTLIST: { keyed: true },
+  CUELIST: { keyed: true },
+};
+
+/** Key addresses and prefixes in the state */
+export const PLAYLISTS_KEY = 'PLISTS';
+export const PLAYLIST_TRACKS_KEY = 'PLIST_TRACKS';
+export const SHOWS_KEY = 'SHOWLIST';
+export const SNAPSHOTS_KEY = 'SNAPSHOTLIST';
+export const CUES_KEY = 'CUELIST';
+
+/**
+ * Request a per-client resource list and emit the entries of the matching reply once.
+ * Subscribes to the reply BEFORE sending the request, so the reply is never missed.
+ * @param conn connection
+ * @param requestCmd full message to send, e.g. `MEDIA_GET_PLISTS` or `SHOWLIST`
+ * @param replyCmd reply command to wait for, e.g. `PLISTS` or `SHOWLIST`
+ */
+export function requestResourceList(
+  conn: MixerConnection,
+  requestCmd: string,
+  replyCmd: string,
+): Observable<string[]> {
+  return new Observable<string[]>(subscriber => {
+    const sub = conn.inbound$
+      .pipe(
+        filter(msg => msg.startsWith(replyCmd + '^')),
+        take(1),
+        // drop the trailing empty entry of an empty list (e.g. `SHOWLIST^`)
+        map(msg => msg.split('^').slice(1).filter(Boolean)),
+      )
+      .subscribe(subscriber);
+    conn.sendMessage(requestCmd);
+    return sub;
+  });
+}

--- a/packages/mixer-connection/src/lib/types.ts
+++ b/packages/mixer-connection/src/lib/types.ts
@@ -40,6 +40,17 @@ export enum PlayerState {
   Paused = 3,
 }
 
+/** A map of playlist name to its list of track names. */
+export type PlaylistsWithTracks = Record<string, string[]>;
+
+export interface ShowDetails {
+  snapshots: string[];
+  cues: string[];
+}
+
+/** A map of show name to its snapshots and cues. */
+export type ShowsWithDetails = Record<string, ShowDetails>;
+
 export enum MtkState {
   Stopped = 0,
   Paused = 1,

--- a/packages/testbed/src/app/pages/player-page/player-page.html
+++ b/packages/testbed/src/app/pages/player-page/player-page.html
@@ -15,19 +15,11 @@
   <sui-mixer-button (press)="player.next()">Next &gt;|</sui-mixer-button>
 </div>
 
-<sui-input-field
-  label="Load playlist"
-  buttonLabel="Load"
-  [value]="playlistFromInput"
-  (valueChange)="player.loadPlaylist($event); this.playlistFromInput = $event"
-/>
+<sui-input-field label="Load playlist" buttonLabel="Load" [value]="playlistFromInput"
+  (valueChange)="player.loadPlaylist($event); this.playlistFromInput = $event" />
 
-<sui-input-field
-  label="Load track from playlist {{ playlistFromInput }}"
-  buttonLabel="Load"
-  value="/Power_Shutoff.mp3"
-  (valueChange)="loadTrack($event)"
-/>
+<sui-input-field label="Load track from playlist {{ playlistFromInput }}" buttonLabel="Load" value="/Power_Shutoff.mp3"
+  (valueChange)="loadTrack($event)" />
 @if (!playlistFromInput) {
 <div class="text-muted">Set playlist first with input above!</div>
 }
@@ -56,3 +48,56 @@
 </sui-mixer-button>
 <sui-mixer-button (press)="rec.recordStart()">REC Start</sui-mixer-button>
 <sui-mixer-button (press)="rec.recordStop()">REC Stop</sui-mixer-button>
+
+<div class="mb-3">
+  <h2 class="mt-5">Playlists</h2>
+
+  <div class="mb-2">
+    <button class="btn btn-sm btn-secondary" (click)="player.refreshPlaylists()">
+      Refresh Playlists
+    </button>
+    <button class="btn btn-sm btn-outline-secondary ms-2" (click)="toggleRawJson()">
+      {{ showRawJson() ? 'Hide' : 'Show' }} raw JSON
+    </button>
+  </div>
+
+  @if (showRawJson()) {
+  <h3 class="h5"><code>playlists$</code></h3>
+  <pre class="bg-light border rounded p-2 mt-2"><code>{{ player.playlists$ | async | json }}</code></pre>
+  <h3 class="h5"><code>playlistsWithTracks$</code></h3>
+  <pre class="bg-light border rounded p-2 mt-2"><code>{{ player.playlistsWithTracks$ | async | json }}</code></pre>
+  }
+
+  <table class="table table-sm table-hover align-middle">
+    <thead>
+      <tr>
+        <th>Playlist / Track</th>
+        <th class="text-end">Action</th>
+      </tr>
+    </thead>
+    <tbody>
+      @for (playlist of player.playlistsWithTracks$ | async | keyvalue: keepOrder; track playlist.key) {
+      <tr>
+        <td><strong>{{ playlist.key }}</strong></td>
+        <td class="text-end">
+          <button class="btn btn-xs btn-dark" (click)="player.loadPlaylist(playlist.key)">Load playlist</button>
+        </td>
+      </tr>
+      @for (track of playlist.value; track track) {
+      <tr>
+        <td class="ps-4">{{ track }}</td>
+        <td class="text-end">
+          <button class="btn btn-xs btn-outline-secondary" (click)="player.loadTrack(playlist.key, track)">
+            Load
+          </button>
+        </td>
+      </tr>
+      }
+      } @empty {
+      <tr>
+        <td colspan="2" class="text-muted">No playlists loaded</td>
+      </tr>
+      }
+    </tbody>
+  </table>
+</div>

--- a/packages/testbed/src/app/pages/player-page/player-page.scss
+++ b/packages/testbed/src/app/pages/player-page/player-page.scss
@@ -1,7 +1,3 @@
-label {
-  font-weight: bold;
-}
-
 table {
   font-size: 0.8rem;
 

--- a/packages/testbed/src/app/pages/player-page/player-page.ts
+++ b/packages/testbed/src/app/pages/player-page/player-page.ts
@@ -1,5 +1,5 @@
-import { AsyncPipe } from '@angular/common';
-import { Component, inject } from '@angular/core';
+import { AsyncPipe, JsonPipe, KeyValuePipe } from '@angular/common';
+import { Component, inject, signal } from '@angular/core';
 import { map } from 'rxjs';
 import { PlayerState } from 'soundcraft-ui-connection';
 
@@ -11,13 +11,14 @@ import { TimePipe } from '../../ui/time.pipe';
 @Component({
   selector: 'sui-player-page',
   templateUrl: './player-page.html',
-  imports: [AsyncPipe, MixerButton, InputField, TimePipe],
+  styleUrl: './player-page.scss',
+  imports: [AsyncPipe, JsonPipe, KeyValuePipe, MixerButton, InputField, TimePipe],
 })
 export class PlayerPage {
   cs = inject(ConnectionService);
 
-  rec = this.cs.conn.recorderDualTrack;
-  player = this.cs.conn.player;
+  rec = this.cs.conn!.recorderDualTrack;
+  player = this.cs.conn!.player;
   playerState$ = this.player.state$.pipe(
     map(s => {
       switch (s) {
@@ -28,10 +29,20 @@ export class PlayerPage {
         case PlayerState.Paused:
           return 'PAUSED';
       }
-    })
+    }),
   );
 
   playlistFromInput = '~all~';
+
+  /** toggle for showing the raw JSON of the playlist listing */
+  showRawJson = signal(false);
+
+  toggleRawJson() {
+    this.showRawJson.update(v => !v);
+  }
+
+  /** keep playlists in the order received instead of the keyvalue pipe's default alphabetical sort */
+  keepOrder = () => 0;
 
   loadTrack(track: string) {
     if (!this.playlistFromInput) {

--- a/packages/testbed/src/app/pages/shows-page/shows-page.html
+++ b/packages/testbed/src/app/pages/shows-page/shows-page.html
@@ -13,6 +13,59 @@
   </button>
 </div>
 
+<div class="mb-3">
+  <h2 class="mt-4">Shows</h2>
+  <button class="btn btn-sm btn-secondary" (click)="showCtrl.refreshShows()">Refresh Shows</button>
+  <button class="btn btn-sm btn-outline-secondary ms-2" (click)="toggleRawJson()">
+    {{ showRawJson() ? 'Hide' : 'Show' }} raw JSON
+  </button>
+
+  @if (showRawJson()) {
+  <pre class="bg-light border rounded p-2 mt-2"><code>{{ showCtrl.shows$ | async | json }}</code></pre>
+  }
+
+  <table class="table table-sm table-hover align-middle mt-3">
+    <thead>
+      <tr>
+        <th>Show / Snapshot / Cue</th>
+        <th class="text-end">Action</th>
+      </tr>
+    </thead>
+    <tbody>
+      @for (show of showCtrl.shows$ | async | keyvalue: keepOrder; track show.key) {
+      <tr>
+        <td><strong>{{ show.key }}</strong></td>
+        <td class="text-end">
+          <button class="btn btn-xs btn-dark" (click)="showCtrl.loadShow(show.key)">Load show</button>
+        </td>
+      </tr>
+      @for (snapshot of show.value.snapshots; track snapshot) {
+      <tr>
+        <td class="ps-4"><span class="text-muted">Snapshot:</span> {{ snapshot }}</td>
+        <td class="text-end">
+          <button class="btn btn-xs btn-outline-secondary" (click)="showCtrl.loadSnapshot(show.key, snapshot)">
+            Load
+          </button>
+        </td>
+      </tr>
+      }
+      @for (cue of show.value.cues; track cue) {
+      <tr>
+        <td class="ps-4"><span class="text-muted">Cue:</span> {{ cue }}</td>
+        <td class="text-end">
+          <button class="btn btn-xs btn-outline-secondary" (click)="showCtrl.loadCue(show.key, cue)">Load</button>
+        </td>
+      </tr>
+      }
+      } @empty {
+      <tr>
+        <td colspan="2" class="text-muted">No shows loaded</td>
+      </tr>
+      }
+    </tbody>
+  </table>
+</div>
+
 <h2 class="mt-4">Load and save</h2>
 
 <div class="container">
@@ -37,41 +90,25 @@
     </button>
   </div>
   <div class="mt-3">
-    <button
-      class="btn btn-secondary me-2"
-      (click)="loadSnapshot()"
-      [disabled]="!formData.show || !formData.snapshot"
-    >
+    <button class="btn btn-secondary me-2" (click)="loadSnapshot()" [disabled]="!formData.show || !formData.snapshot">
       Load snapshot <strong>{{ formData.snapshot }}</strong> in show
       <strong>{{ formData.show }}</strong>
     </button>
   </div>
   <div class="mt-3">
-    <button
-      class="btn btn-secondary me-2"
-      (click)="loadCue()"
-      [disabled]="!formData.show || !formData.cue"
-    >
+    <button class="btn btn-secondary me-2" (click)="loadCue()" [disabled]="!formData.show || !formData.cue">
       Load cue <strong>{{ formData.cue }}</strong> in show <strong>{{ formData.show }}</strong>
     </button>
   </div>
 
   <div class="mt-3">
-    <button
-      class="btn btn-warning me-2"
-      (click)="saveSnapshot()"
-      [disabled]="!formData.show || !formData.snapshot"
-    >
+    <button class="btn btn-warning me-2" (click)="saveSnapshot()" [disabled]="!formData.show || !formData.snapshot">
       Save snapshot <strong>{{ formData.snapshot }}</strong> in show
       <strong>{{ formData.show }}</strong>
     </button>
   </div>
   <div class="mt-3">
-    <button
-      class="btn btn-warning me-2"
-      (click)="saveCue()"
-      [disabled]="!formData.show || !formData.cue"
-    >
+    <button class="btn btn-warning me-2" (click)="saveCue()" [disabled]="!formData.show || !formData.cue">
       Save cue <strong>{{ formData.cue }}</strong> in show
       <strong>{{ formData.show }}</strong>
     </button>

--- a/packages/testbed/src/app/pages/shows-page/shows-page.ts
+++ b/packages/testbed/src/app/pages/shows-page/shows-page.ts
@@ -1,5 +1,5 @@
-import { AsyncPipe } from '@angular/common';
-import { Component, inject } from '@angular/core';
+import { AsyncPipe, JsonPipe, KeyValuePipe } from '@angular/common';
+import { Component, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { ConnectionService } from '../../connection.service';
@@ -8,17 +8,27 @@ import { ConnectionService } from '../../connection.service';
   selector: 'sui-shows-page',
   templateUrl: './shows-page.html',
   styleUrl: './shows-page.scss',
-  imports: [AsyncPipe, FormsModule],
+  imports: [AsyncPipe, JsonPipe, KeyValuePipe, FormsModule],
 })
 export class ShowsPage {
   cs = inject(ConnectionService);
-  showCtrl = this.cs.conn.shows;
+  showCtrl = this.cs.conn!.shows;
 
   formData = {
     show: 'testshow',
     snapshot: '',
     cue: '',
   };
+
+  /** keep shows in the order received instead of the keyvalue pipe's default alphabetical sort */
+  keepOrder = () => 0;
+
+  /** toggle for showing the raw JSON of the show listing */
+  showRawJson = signal(false);
+
+  toggleRawJson() {
+    this.showRawJson.update(v => !v);
+  }
 
   loadShow() {
     if (this.formData.show) {

--- a/packages/testbed/src/app/ui/mixer-button/mixer-button.scss
+++ b/packages/testbed/src/app/ui/mixer-button/mixer-button.scss
@@ -9,7 +9,8 @@ button {
   outline: none;
   margin-right: 10px;
   margin-top: 10px;
-  padding: 4px;
+  padding: 4px 10px;
+  border-radius: 5px;
 
   &:hover {
     background: color.adjust(black, $lightness: 20%);

--- a/packages/testbed/src/styles.scss
+++ b/packages/testbed/src/styles.scss
@@ -12,3 +12,10 @@ p {
     width: 150px;
   }
 }
+
+/* Extra-small button variant (smaller than Bootstrap's btn-sm) */
+.btn-xs {
+  --bs-btn-padding-y: 0.05rem;
+  --bs-btn-padding-x: 0.3rem;
+  --bs-btn-font-size: 0.7rem;
+}


### PR DESCRIPTION
## Summary

Playlists and shows/snapshots/cues are sent **per-client on request** and are not part of the global `SETD`/`SETS` mixer state. This PR adds a generic per-client **resource-listing** mechanism and exposes the data through the existing `Player` and `ShowController` facades, plus testbed UI to load them.

## Mechanism

- **`state/resource-lists.ts`** (new) — `RESOURCE_LIST_CONFIG` maps each reply command to whether it is keyed by a parent (`PLISTS`/`SHOWLIST` flat; `PLIST_TRACKS`/`SNAPSHOTLIST`/`CUELIST` keyed). Also a shared `requestResourceList(conn, requestCmd, replyCmd)` helper that subscribes to the reply on `inbound$` before sending, and filters trailing-empty entries (empty lists are sent as e.g. `CUELIST^Default^`).
- **`MixerStore.resourceListState$`** — a `connectable`/`ReplaySubject` flat map `Record<string, string[]>` keyed by message *address* (command + key parts), scanned from `inbound$` (so our own outbound requests don't pollute state). Mirrors the existing `syncState$` pattern; the flat `state$` stays pure `SETD`/`SETS`.

## API

- **`Player`**: `playlists$`, `playlistsWithTracks$` (`Record<string, string[]>`), `refreshPlaylists()`
- **`ShowController`**: `shows$` — `Record<string, { snapshots: string[]; cues: string[] }>` (snapshots and cues are **not** hierarchical; both hang off a show in parallel), `refreshShows()`
- Both auto-fetch on every connection open (and reconnect).

## Testbed

- Player page: table listing playlists/tracks with small "Load" buttons + "Refresh Playlists".
- Shows page: table listing shows with their snapshots/cues + "Refresh Shows".

## Docs

- `media-player.md` and `shows.md` updated with the new observables/methods and a note on per-client fetching.

## Tests

- `resourceListState$` scan (flat/keyed, replace, empty trailing-separator, ignore-unconfigured).
- `Player` and `ShowController` listing specs (auto-fetch, fan-out, composed shape, pruning) via `MockWebSocket`.
- Outbound-message coverage for `refreshPlaylists()` / `refreshShows()`.

All 530 tests pass; lint, format, and testbed build are green.