### PR TITLE
build: migrate vite config to inferred targets

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -46,5 +46,18 @@
   },
   "defaultBase": "main",
   "analytics": false,
-  "neverConnectToCloud": true
+  "neverConnectToCloud": true,
+  "plugins": [
+    {
+      "plugin": "@nx/vite/plugin",
+      "options": {
+        "buildTargetName": "build",
+        "serveTargetName": "serve",
+        "previewTargetName": "preview",
+        "serveStaticTargetName": "serve-static",
+        "devTargetName": "dev",
+        "typecheckTargetName": "typecheck"
+      }
+    }
+  ]
 }

--- a/packages/mixer-connection/project.json
+++ b/packages/mixer-connection/project.json
@@ -6,11 +6,13 @@
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/vite:build",
-      "outputs": ["{options.outputPath}"],
+      "outputs": [
+        "{projectRoot}/{options.outDir}",
+        "{workspaceRoot}/dist/packages/mixer-connection"
+      ],
       "options": {
-        "outputPath": "dist/packages/mixer-connection",
-        "configFile": "packages/mixer-connection/vite.config.mts"
+        "config": "./vite.config.mts",
+        "outDir": "../../dist/packages/mixer-connection"
       }
     },
     "lint": {

--- a/packages/mixer-connection/vite.config.mts
+++ b/packages/mixer-connection/vite.config.mts
@@ -1,10 +1,20 @@
 /// <reference types='vitest' />
 import { defineConfig } from 'vite';
-import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 
 import dts from 'vite-plugin-dts';
 import { join } from 'path';
 import copy from 'rollup-plugin-copy';
+
+// These options were migrated by @nx/vite:convert-to-inferred from the project.json file.
+const configValues = { default: {} };
+
+// Determine the correct configValue to use based on the configuration
+const nxConfiguration = process.env.NX_TASK_TARGET_CONFIGURATION ?? 'default';
+
+const options = {
+  ...configValues.default,
+  ...(configValues[nxConfiguration] ?? {}),
+};
 
 export default defineConfig({
   root: __dirname,
@@ -14,12 +24,10 @@ export default defineConfig({
       entryRoot: 'src',
       tsconfigPath: join(__dirname, 'tsconfig.lib.json'),
     }),
-    nxViteTsPaths(),
   ],
-  // Uncomment this if you are using workers.
-  // worker: {
-  //   plugins: () => [ nxViteTsPaths() ],
-  // },
+  resolve: {
+    tsconfigPaths: true,
+  },
   build: {
     outDir: '../../dist/packages/mixer-connection',
     reportCompressedSize: true,


### PR DESCRIPTION
## Summary
- Replace deprecated `nxViteTsPaths` plugin (removed in Nx v24) with Vite 8's native `resolve.tsconfigPaths: true`
- Migrate `mixer-connection` build target to Nx inferred targets (`@nx/vite/plugin`)

## Test plan
- `npx nx build mixer-connection` — clean, no tsconfig-paths warnings
- `npx nx test mixer-connection` — 531 passed
- `npx nx format:check` — clean