### PR TITLE
build: copy package.json into dist to fix npm publish

### DIFF
--- a/packages/mixer-connection/vite.config.mts
+++ b/packages/mixer-connection/vite.config.mts
@@ -24,6 +24,16 @@ export default defineConfig({
       entryRoot: 'src',
       tsconfigPath: join(__dirname, 'tsconfig.lib.json'),
     }),
+    copy({
+      verbose: true,
+      targets: [
+        {
+          src: ['README.md', 'package.json'],
+          dest: '../../dist/packages/mixer-connection/',
+        },
+      ],
+      hook: 'writeBundle',
+    }),
   ],
   resolve: {
     tsconfigPaths: true,
@@ -40,17 +50,6 @@ export default defineConfig({
     },
     rolldownOptions: {
       external: [],
-      plugins: [
-        copy({
-          targets: [
-            {
-              src: 'packages/mixer-connection/README.md',
-              dest: 'dist/packages/mixer-connection/',
-            },
-          ],
-          hook: 'writeBundle',
-        }),
-      ],
     },
   },
 });


### PR DESCRIPTION
The inferred vite build (#318) stopped auto-generating `package.json` in the dist output, so `npm publish` failed with ENOENT.

Copies `package.json` and `README.md` into dist via `rollup-plugin-copy` and fixes the project-relative paths (the old README copy was silently failing too).