### PR TITLE
perf(mixer-connection): reduce allocations on message hot paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,13 @@ npx nx serve testbed
 
 # Guidelines for working with this project
 
+## Performance work
+
+- Performance optimizations must be justified by real message frequency, not synthetic benchmarks. Hot paths (hundreds of messages/sec): the `state$` scan, the inbound message pipeline, VU frames, fade-transition writes. Cold paths (user-paced, a few messages per session): `syncState$`, `resourceListState$`, user actions — do not micro-optimize these.
+- Streams with user-paced updates keep immutable emissions, so consumers get snapshot semantics (`pairwise`, reference comparison, safely held references). The mutable accumulator in `state$` is a documented exception for the hot path only — do not spread that pattern to other streams.
+
+## General
+
 - Before committing, verify correctness by running tests (`npx nx test`), linting (`npx nx lint`) and code formatting (`npx nx format:check`). Fix formatting with `npx nx format:write`.
 - Always run `npx nx format:check` before pushing.
 - Do not use `--reporter=verbose` with `npx nx test` — it causes tests to hang.

--- a/docs/docs/usage/connection.md
+++ b/docs/docs/usage/connection.md
@@ -25,3 +25,6 @@ All three methods return a Promise that resolves when the operation has finished
 This is useful when you want to wait for the connection to be open before you start using the mixer.
 Please note that these Promises will not reject on errors.
 If you want to receive errors, use the `status$` Observable instead.
+
+Calling `connect()` while a connection is already open or being established has no additional effect:
+the method just returns a Promise that resolves when the connection is open.

--- a/packages/mixer-connection/src/lib/facade/volume-bus.ts
+++ b/packages/mixer-connection/src/lib/facade/volume-bus.ts
@@ -16,6 +16,9 @@ import { VolumeBusType } from '../types';
 export class VolumeBus implements FadeableChannel {
   private transitionSources$ = new Subject<TransitionSource>();
 
+  /** State path of this bus, e.g. `settings.solovol` or `settings.hpvol.0` */
+  private busPath = `settings.${this.busName}${this.busId ? '.' + (this.busId - 1) : ''}`;
+
   /** Linear level of the volume bus (between `0` and `1`) */
   readonly faderLevel$ = this.store.state$.pipe(
     select(selectVolumeBusValue(this.busName, this.busId ? this.busId - 1 : undefined)),
@@ -78,8 +81,7 @@ export class VolumeBus implements FadeableChannel {
   }
 
   private setFaderLevelRaw(value: number) {
-    const bus = `${this.busName}${this.busId ? '.' + (this.busId - 1) : ''}`;
-    this.conn.setd(`settings.${bus}`, value);
+    this.conn.setd(this.busPath, value);
   }
 
   /**

--- a/packages/mixer-connection/src/lib/mixer-connection.spec.ts
+++ b/packages/mixer-connection/src/lib/mixer-connection.spec.ts
@@ -84,6 +84,66 @@ describe('MixerConnection', () => {
         expect(messages).toEqual(['SETD^i.0.mix^0.5', 'SETD^i.1.mix^0.8']);
       });
     });
+
+    describe('when connect() is called multiple times', () => {
+      it('should resolve immediately when already connected', async () => {
+        const connectPromise = conn.connect();
+        wsMock.simulateOpen();
+        await connectPromise;
+
+        // must resolve without another open event
+        await conn.connect();
+
+        expect(conn.status).toBe(ConnectionStatus.Open);
+      });
+
+      it('should not process inbound messages twice after a duplicate connect()', async () => {
+        const connectPromise = conn.connect();
+        wsMock.simulateOpen();
+        await connectPromise;
+
+        await conn.connect();
+
+        const messages: string[] = [];
+        conn.inbound$.subscribe(msg => messages.push(msg));
+        wsMock.simulateMessage('3:::SETD^i.0.mix^0.5');
+
+        expect(messages).toEqual(['SETD^i.0.mix^0.5']);
+      });
+
+      it('should share the connection attempt when called while opening', async () => {
+        const first = conn.connect();
+        const second = conn.connect();
+
+        wsMock.simulateOpen();
+        await first;
+        await second;
+
+        const messages: string[] = [];
+        conn.inbound$.subscribe(msg => messages.push(msg));
+        wsMock.simulateMessage('3:::SETD^i.0.mix^0.5');
+
+        expect(messages).toEqual(['SETD^i.0.mix^0.5']);
+      });
+
+      it('should connect again after disconnect', async () => {
+        const first = conn.connect();
+        wsMock.simulateOpen();
+        await first;
+
+        conn.disconnect();
+
+        const second = conn.connect();
+        wsMock.simulateOpen();
+        await second;
+
+        const messages: string[] = [];
+        conn.inbound$.subscribe(msg => messages.push(msg));
+        wsMock.simulateMessage('3:::SETD^i.0.mix^0.5');
+
+        expect(messages).toEqual(['SETD^i.0.mix^0.5']);
+      });
+    });
   });
 
   describe('sendMessage()', () => {

--- a/packages/mixer-connection/src/lib/mixer-connection.ts
+++ b/packages/mixer-connection/src/lib/mixer-connection.ts
@@ -2,6 +2,7 @@ import {
   interval,
   merge,
   Subject,
+  Subscription,
   filter,
   switchMap,
   takeUntil,
@@ -42,6 +43,12 @@ export class MixerConnection {
   private statusSubject$ = new Subject<ConnectionEvent>();
   private outboundSubject$ = new Subject<string>();
   private inboundSubject$ = new Subject<string>();
+
+  /**
+   * active subscription that pipes socket messages into the inbound stream.
+   * Used to guard against parallel connections when connect() is called multiple times.
+   */
+  private socketSubscription?: Subscription;
 
   private _status: ConnectionStatus = ConnectionStatus.Close;
 
@@ -108,8 +115,31 @@ export class MixerConnection {
     this.outbound$.subscribe(this.socket$);
   }
 
+  /** Returns a promise that resolves when the connection status becomes Open */
+  private waitForOpenStatus(): Promise<void> {
+    return firstValueFrom(
+      this.status$.pipe(
+        filter(status => status.type === ConnectionStatus.Open),
+        map(() => {
+          return;
+        }),
+      ),
+    );
+  }
+
   /** Connect to socket and retry if connection lost */
   connect() {
+    // Guard against parallel connections:
+    // every additional call would create another socket subscription,
+    // causing all inbound messages to be processed multiple times.
+    if (this.socketSubscription && !this.socketSubscription.closed) {
+      if (this._status === ConnectionStatus.Open) {
+        return Promise.resolve();
+      }
+      // a connection attempt is already in progress: wait for it to open
+      return this.waitForOpenStatus();
+    }
+
     this.statusSubject$.next({ type: ConnectionStatus.Opening });
     const messages$ = this.socket$.pipe(
       tap({
@@ -136,7 +166,7 @@ export class MixerConnection {
     // One raw message can contain multiple lines with commands: split them into single emissions.
     // Single-line messages are the common case (every VU frame, every SETD/SETS),
     // so they take an allocation-free fast path.
-    messages$.subscribe(message => {
+    this.socketSubscription = messages$.subscribe(message => {
       if (message.includes('\n')) {
         for (const line of message.split('\n')) {
           this.inboundSubject$.next(line);
@@ -147,14 +177,7 @@ export class MixerConnection {
     });
 
     // return promise that resolves when the connection is open
-    return firstValueFrom(
-      this.status$.pipe(
-        filter(status => status.type === ConnectionStatus.Open),
-        map(() => {
-          return;
-        }),
-      ),
-    );
+    return this.waitForOpenStatus();
 
     /*
     // Keep for later: echo
@@ -211,14 +234,7 @@ export class MixerConnection {
     this.disconnect();
 
     // return promise that resolves when the connection is open again
-    return firstValueFrom(
-      this.status$.pipe(
-        filter(status => status.type === ConnectionStatus.Open),
-        map(() => {
-          return;
-        }),
-      ),
-    );
+    return this.waitForOpenStatus();
   }
 
   /**

--- a/packages/mixer-connection/src/lib/mixer-connection.ts
+++ b/packages/mixer-connection/src/lib/mixer-connection.ts
@@ -2,7 +2,6 @@ import {
   interval,
   merge,
   Subject,
-  mergeMap,
   filter,
   switchMap,
   takeUntil,
@@ -131,11 +130,21 @@ export class MixerConnection {
       }),
       filter(message => message.startsWith('3:::')), // only use messages with `3:::` prefix
       map(message => message.slice(4)), // remove prefix
-      mergeMap(message => message.split('\n')), // one message can contain multiple lines with commands. split them into single emissions
     );
 
-    // send all messages to our global stream that survives reconnects
-    messages$.subscribe(msg => this.inboundSubject$.next(msg));
+    // Send all messages to our global stream that survives reconnects.
+    // One raw message can contain multiple lines with commands: split them into single emissions.
+    // Single-line messages are the common case (every VU frame, every SETD/SETS),
+    // so they take an allocation-free fast path.
+    messages$.subscribe(message => {
+      if (message.includes('\n')) {
+        for (const line of message.split('\n')) {
+          this.inboundSubject$.next(line);
+        }
+      } else {
+        this.inboundSubject$.next(message);
+      }
+    });
 
     // return promise that resolves when the connection is open
     return firstValueFrom(

--- a/packages/mixer-connection/src/lib/state/mixer-store.ts
+++ b/packages/mixer-connection/src/lib/state/mixer-store.ts
@@ -61,8 +61,13 @@ export class MixerStore {
    */
   readonly resourceListState$ = connectable(
     this.conn.inbound$.pipe(
+      // check the command prefix before splitting, so that high-frequency messages
+      // (e.g. VU2 meter frames) don't get split into arrays just to be discarded
+      filter(msg => {
+        const sep = msg.indexOf('^');
+        return (sep === -1 ? msg : msg.slice(0, sep)) in RESOURCE_LIST_CONFIG;
+      }),
       map(msg => msg.split('^')),
-      filter(parts => parts[0] in RESOURCE_LIST_CONFIG),
       scan(
         (acc, parts) => {
           const addrLen = RESOURCE_LIST_CONFIG[parts[0]].keyed ? 2 : 1;

--- a/packages/mixer-connection/src/lib/state/state-selectors.ts
+++ b/packages/mixer-connection/src/lib/state/state-selectors.ts
@@ -230,14 +230,12 @@ export const selectFxType: Selector<FxType> = (bus = 1) => {
  * @param channel
  */
 export const selectStereoIndex: Selector<number> = (channelType: ChannelType, channel: number) => {
+  // only input, line, player and aux can be linked
+  if (!['i', 'l', 'p', 'a'].includes(channelType)) {
+    return () => -1;
+  }
   const path = joinStatePath(channelType, channel - 1, 'stereoIndex');
-  return state => {
-    // only input, line, player and aux can be linked
-    if (['i', 'l', 'p', 'a'].includes(channelType)) {
-      return getValueFromObject(state, path, -1);
-    }
-    return -1;
-  };
+  return state => getValueFromObject(state, path, -1);
 };
 
 /**

--- a/packages/mixer-connection/src/lib/state/state-selectors.ts
+++ b/packages/mixer-connection/src/lib/state/state-selectors.ts
@@ -60,11 +60,10 @@ const selectGenericChannelProperty = <T>(
     }
     case 'aux':
     case 'fx':
-    case 'mtx':
-      return state => {
-        const path = joinStatePath(channelType, channel - 1, busType, bus - 1, property);
-        return getValueFromObject(state, path, defaultValue);
-      };
+    case 'mtx': {
+      const path = joinStatePath(channelType, channel - 1, busType, bus - 1, property);
+      return state => getValueFromObject(state, path, defaultValue);
+    }
   }
 };
 


### PR DESCRIPTION
## Summary

Five performance fixes on the message-processing hot paths of the `mixer-connection` library, found during an iterative performance review, plus one connection-robustness fix. Each fix is a separate commit, and each was **benchmarked independently** (old vs. new implementation, median of 9 alternating rounds, isolated Node processes, checksum-verified equivalence) — see the results table below. The benchmark numbers are also recorded in each commit message.

Three further candidates were benchmarked and **dropped**:
- *hoist VU parser descriptor table* and *SETD/SETS check via single char* — only marginal gains (1.03× / 1.1×)
- *mutable scan accumulation for `syncState$`/`resourceListState$`* — 12–3447× on synthetic workloads, but these streams update only on user intent (channel selection, list requests — a few messages per session, unlike the SETD/SETS flood), and immutable emissions provide snapshot semantics for consumers (`pairwise`, reference comparison, safely held references). The mutable pattern stays a documented exception for the hot `state$` only.

### 1. Filter resource list messages before splitting (`f89f09e`)
`resourceListState$` split **every** inbound message into an array before filtering — including high-frequency VU2 meter frames and all SETD/SETS traffic. The command prefix is now checked allocation-free (`indexOf`/`slice`) before splitting; only the ~5 rare resource list commands get split.

### 2. Hoist linkable-type check out of `selectStereoIndex` (`7bab80e`)
Every channel facade permanently subscribes to `stereoIndex$` for stereo-link tracking, so this projector runs per state message per channel instance. The `['i','l','p','a']` array was allocated on every call; the check now happens once at selector creation, and non-linkable types get a constant `() => -1` projector.

### 3. Precompute state path in aux/fx/mtx channel selectors (`5a5d58a`)
The aux/fx/mtx branch of `selectGenericChannelProperty` (backing `pan$`, `mute$`, `postproc$` on send channels) rebuilt the path string inside the projector on every emission. It is now computed once at selector creation, matching the existing `master` branch.

### 4. Split inbound multi-line messages allocation-free (`63d3f6c`)
The inbound pipeline split every raw socket message into an array of lines and passed it through an inner Observable, although single-line messages are the common case (every VU frame, every SETD/SETS). The split now happens imperatively in the subscription callback, with an allocation-free fast path for single-line messages.

### 5. Guard `connect()` against parallel connections (`039cc5a`) — *fix, not perf*
Every call to `connect()` created another socket subscription, so calling it again on an open or opening connection caused all inbound messages to be **processed multiple times**. Additional `connect()` calls are now no-ops that resolve when the connection is open. Includes 4 new tests and a docs note in `connection.md`.

### 6. Precompute volume bus state path (`e61a1b6`)
`VolumeBus` rebuilt its state path string on every fader write (runs per frame during fade transitions). The path is now computed once at construction, matching the `fullChannelId` pattern used by all other facades.

## Benchmark results

Old vs. new implementations copied verbatim from each commit diff; realistic workloads (real 434-char VU frame payload from the test fixtures); median of 9 alternating rounds after warmup; one Node process (v24) per fix; checksums accumulated to prevent dead-code elimination and verify behavioral equivalence.

| # | Fix | Workload | Old | New | Speedup |
|---|---|---|---|---|---|
| 1 | filter resource lists before splitting | 100k inbound msgs (50% VU frames) | 16.3 ms | 8.5 ms | **1.9×** |
| 2 | hoist `selectStereoIndex` type check | 10M projector calls | 86.5 ms | 48.0 ms | **1.8×** |
| 3 | precompute aux/fx/mtx selector path | 5M projector calls | 609.9 ms | 23.0 ms | **26.5×** |
| 4 | imperative line split vs `mergeMap` | 200k inbound msgs | 59.8 ms | 19.8 ms | **3.0×** |
| 5 | connect() guard (duplicate chain) | 100k msgs, 2 chains vs 1 | 32.1 ms | 16.7 ms | **1.9×** |
| 6 | precompute volume bus path | 3M fader writes | 78.0 ms | 39.0 ms | **2.0×** |
| — | *(dropped)* mutable scan accumulation | synthetic bursts | 2446.9 ms | 0.7 ms | 3447× — but streams are user-paced; immutability kept |
| — | *(dropped)* hoist VU descriptor table | 100k VU frames parsed | 76.8 ms | 74.3 ms | 1.03× |
| — | *(dropped)* SETD/SETS check via char | 1M state-scan messages | 117.0 ms | 106.6 ms | 1.1× |

All checksums matched old == new, except fix 5 where they intentionally differ (200000 vs. 100000 messages processed) — which is precisely the bug: before the guard, a duplicate `connect()` made every inbound message get processed twice.

## Test plan

- [x] `npx nx test mixer-connection` — 535/535 pass (4 new tests for the connect guard); existing specs pin down all touched behaviors (bus-variant selector paths, stereo-index defaults and non-linkable types, resource list parsing incl. non-list messages, multi-line message splitting)
- [x] `npx nx lint mixer-connection` — clean
- [x] `npx nx format:check` — clean
- [x] `npx nx build mixer-connection` — builds; `dist` bundles unchanged in structure
- [x] independent old-vs-new benchmarks for all fixes (table above)

Docs updated: `connection.md` notes that duplicate `connect()` calls have no additional effect. No other API surface changes.