### PR TITLE
test(mixer-connection): cover FX/matrix stereo-link mirroring and edge cases

### DIFF
--- a/packages/mixer-connection/src/lib/facade/channel-sync.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/channel-sync.spec.ts
@@ -47,6 +47,14 @@ describe('ChannelSync', () => {
     expect(nextCallback).not.toHaveBeenCalled();
   });
 
+  it('should not send anything from selectChannel when the device model is unknown', () => {
+    // no model-info message has been received yet, so the model is undefined
+    vi.spyOn(conn.conn, 'sendMessage');
+    cs.selectChannel('i', 3);
+    cs.selectChannel('master');
+    expect(conn.conn.sendMessage).not.toHaveBeenCalled();
+  });
+
   describe('selectChannel', () => {
     beforeEach(() => {
       vi.spyOn(conn.conn, 'sendMessage');

--- a/packages/mixer-connection/src/lib/facade/master-bus.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/master-bus.spec.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { firstValueFrom } from 'rxjs';
 import { SoundcraftUI } from '../soundcraft-ui';
+import { Easings } from '../utils/transitions/easings';
+import { DBToFaderValue } from '../utils/value-converters';
 import { MasterBus } from './master-bus';
 
 describe('Master Bus', () => {
@@ -157,7 +159,35 @@ describe('Master Bus', () => {
       master.changeFaderLevelDB(3);
 
       expect(await firstValueFrom(master.faderLevelDB$)).toBe(-97);
-      expect(await firstValueFrom(master.faderLevel$)).not.toBe(0);
+      expect(await firstValueFrom(master.faderLevel$)).toBe(DBToFaderValue(-97));
+    });
+  });
+
+  describe('fader transition', () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it('fadeTo should transition the master fader to the target linear value', () => {
+      const results: number[] = [];
+      master.faderLevel$.subscribe(v => results.push(v));
+
+      master.setFaderLevel(0.3);
+      master.fadeTo(0.8, 1000, Easings.Linear);
+      vi.advanceTimersByTime(1000);
+
+      expect(results.length).toBeGreaterThan(2); // multiple intermediate steps
+      expect(results.at(-1)).toBe(0.8);
+    });
+
+    it('fadeToDB should transition the master fader to the target dB value', () => {
+      const results: number[] = [];
+      master.faderLevelDB$.subscribe(v => results.push(v));
+
+      master.setFaderLevelDB(-60);
+      master.fadeToDB(-3, 1000, Easings.Linear);
+      vi.advanceTimersByTime(1000);
+
+      expect(results.at(-1)).toBe(-3);
     });
   });
 });

--- a/packages/mixer-connection/src/lib/facade/mtx-bus-channel.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/mtx-bus-channel.spec.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { firstValueFrom } from 'rxjs';
 import { SoundcraftUI } from '../soundcraft-ui';
+import { Easings } from '../utils/transitions/easings';
+import { DBToFaderValue } from '../utils/value-converters';
 import { MtxBusChannel } from './mtx-bus-channel';
 import { MtxChannel } from './mtx-channel';
 
@@ -39,6 +41,42 @@ describe('MTX Bus Channel', () => {
 
       channel.changeFaderLevel(-0.4);
       expect(await firstValueFrom(channel.faderLevel$)).toBe(0.3);
+    });
+
+    it('changeFaderLevelDB should change the level from -Infinity dB upwards', async () => {
+      channel.setFaderLevel(0); // -Infinity dB
+      channel.changeFaderLevelDB(3);
+
+      expect(await firstValueFrom(channel.faderLevelDB$)).toBe(-97);
+      expect(await firstValueFrom(channel.faderLevel$)).toBe(DBToFaderValue(-97));
+    });
+  });
+
+  describe('fader transition', () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it('fadeTo should transition the matrix source to the target linear value', () => {
+      const results: number[] = [];
+      channel.faderLevel$.subscribe(v => results.push(v));
+
+      channel.setFaderLevel(0.3);
+      channel.fadeTo(0.8, 1000, Easings.Linear);
+      vi.advanceTimersByTime(1000);
+
+      expect(results.length).toBeGreaterThan(2); // multiple intermediate steps
+      expect(results.at(-1)).toBe(0.8);
+    });
+
+    it('fadeToDB should transition the matrix source to the target dB value', () => {
+      const results: number[] = [];
+      channel.faderLevelDB$.subscribe(v => results.push(v));
+
+      channel.setFaderLevelDB(-60);
+      channel.fadeToDB(-3, 1000, Easings.Linear);
+      vi.advanceTimersByTime(1000);
+
+      expect(results.at(-1)).toBe(-3);
     });
   });
 

--- a/packages/mixer-connection/src/lib/facade/player.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/player.spec.ts
@@ -97,6 +97,18 @@ describe('Player', () => {
       expect(await firstValueFrom(mixer.player.playlists$)).toEqual(['List1', 'List2', '~all~']);
     });
 
+    it('playlists$ should only re-emit when the list of names actually changes', () => {
+      const emissions: string[][] = [];
+      mixer.player.playlists$.subscribe(names => emissions.push(names));
+
+      socket.simulateMessage('3:::PLISTS^List1^List2');
+      socket.simulateMessage('3:::PLISTS^List1^List2'); // identical -> suppressed
+      socket.simulateMessage('3:::PLISTS^List1^Other'); // same length, different name
+      socket.simulateMessage('3:::PLISTS^List1'); // different length
+
+      expect(emissions).toEqual([['List1', 'List2'], ['List1', 'Other'], ['List1']]);
+    });
+
     it('playlistsWithTracks$', async () => {
       socket.simulateMessage('3:::PLISTS^List1^List2^~all~');
       socket.simulateMessage('3:::PLIST_TRACKS^List1^a.mp3^b.mp3');

--- a/packages/mixer-connection/src/lib/facade/stereo-link.spec.ts
+++ b/packages/mixer-connection/src/lib/facade/stereo-link.spec.ts
@@ -241,4 +241,196 @@ describe('Stereo linking', () => {
       expect(messages).toEqual(['SETD^i.2.aux.1.value^0.5']);
     });
   });
+
+  describe('FX channels', () => {
+    // FX buses are never stereo-linked pairs (unlike AUX buses), so only the source
+    // channel can be linked. Mirroring therefore reaches at most the neighbour source.
+    it('should mirror commands to the linked neighbour (first in link)', () => {
+      conn.conn.sendMessage('SETD^i.2.stereoIndex^0'); // input 3 & 4 linked, input 3 first
+      const channel = conn.fx(1).input(3);
+
+      let messages = collectMessages(conn);
+      channel.setFaderLevel(0.5);
+      expect(messages).toEqual(['SETD^i.2.fx.0.value^0.5', 'SETD^i.3.fx.0.value^0.5']);
+
+      messages = collectMessages(conn);
+      channel.setMute(true);
+      expect(messages).toEqual(['SETD^i.2.fx.0.mute^1', 'SETD^i.3.fx.0.mute^1']);
+
+      messages = collectMessages(conn);
+      channel.setPost(true);
+      expect(messages).toEqual(['SETD^i.2.fx.0.post^1', 'SETD^i.3.fx.0.post^1']);
+    });
+
+    it('should mirror commands to the linked neighbour (second in link)', () => {
+      conn.conn.sendMessage('SETD^i.3.stereoIndex^1'); // input 3 & 4 linked, input 4 second
+      const channel = conn.fx(1).input(4);
+
+      const messages = collectMessages(conn);
+      channel.setFaderLevel(0.5);
+      expect(messages).toEqual(['SETD^i.3.fx.0.value^0.5', 'SETD^i.2.fx.0.value^0.5']);
+    });
+
+    it('should not mirror anything when the channel is not linked', () => {
+      // unrelated message so the state exists and stereoIndex resolves to -1
+      conn.conn.sendMessage('SETD^m.mix^0.5');
+      const channel = conn.fx(1).input(3);
+
+      const messages = collectMessages(conn);
+      channel.setFaderLevel(0.5);
+      expect(messages).toEqual(['SETD^i.2.fx.0.value^0.5']);
+    });
+  });
+
+  describe('matrix channels', () => {
+    // A matrix source has two independently-linkable axes: the source (an AUX bus or
+    // subgroup) and the matrix output (which lives in an `a` slot, keyed like an AUX
+    // bus). Both use `selectStereoIndex('a', ...)`. As with AUX channels, a single
+    // command can reach up to 4 channels; PAN only mirrors across the matrix-output
+    // link, never to the source neighbour.
+    describe('AUX source — only the source is linked', () => {
+      it('should mirror to the neighbour source on the same matrix', () => {
+        conn.conn.sendMessage('SETD^a.6.stereoIndex^-1'); // matrix output (mtx 7) not linked
+        conn.conn.sendMessage('SETD^a.2.stereoIndex^0'); // aux 3 & 4 linked, aux 3 first
+        const channel = conn.mtx(7).aux(3);
+
+        const messages = collectMessages(conn);
+        channel.setFaderLevel(0.5);
+        expect(messages).toEqual(['SETD^a.2.mtx.6.value^0.5', 'SETD^a.3.mtx.6.value^0.5']);
+      });
+    });
+
+    describe('AUX source — only the matrix output is linked', () => {
+      beforeEach(() => {
+        conn.conn.sendMessage('SETD^a.2.stereoIndex^-1'); // aux 3 not linked
+        conn.conn.sendMessage('SETD^a.6.stereoIndex^0'); // matrix 7 & 8 linked, matrix 7 first
+      });
+
+      it('should mirror this source to the linked matrix output', () => {
+        const channel = conn.mtx(7).aux(3);
+
+        const messages = collectMessages(conn);
+        channel.setFaderLevel(0.5);
+        expect(messages).toEqual(['SETD^a.2.mtx.6.value^0.5', 'SETD^a.2.mtx.7.value^0.5']);
+      });
+
+      it('should mirror PAN to this source on the linked matrix output', () => {
+        const channel = conn.mtx(7).aux(3);
+
+        const messages = collectMessages(conn);
+        channel.setPan(0.5);
+        expect(messages).toEqual(['SETD^a.2.mtx.6.pan^0.5', 'SETD^a.2.mtx.7.pan^0.5']);
+      });
+    });
+
+    describe('AUX source — both the source and the matrix output are linked (4 channels)', () => {
+      beforeEach(() => {
+        conn.conn.sendMessage('SETD^a.2.stereoIndex^0'); // aux 3 & 4 linked, aux 3 first
+        conn.conn.sendMessage('SETD^a.6.stereoIndex^0'); // matrix 7 & 8 linked, matrix 7 first
+      });
+
+      it('should set faderLevel on all four channels', () => {
+        const channel = conn.mtx(7).aux(3);
+
+        const messages = collectMessages(conn);
+        channel.setFaderLevel(0.5);
+        expect(messages).toEqual([
+          'SETD^a.2.mtx.6.value^0.5', // self
+          'SETD^a.3.mtx.6.value^0.5', // neighbour source on this matrix
+          'SETD^a.2.mtx.7.value^0.5', // this source on the linked matrix
+          'SETD^a.3.mtx.7.value^0.5', // neighbour source on the linked matrix
+        ]);
+      });
+
+      it('should set MUTE on all four channels', () => {
+        const channel = conn.mtx(7).aux(3);
+
+        const messages = collectMessages(conn);
+        channel.setMute(true);
+        expect(messages).toEqual([
+          'SETD^a.2.mtx.6.mute^1',
+          'SETD^a.3.mtx.6.mute^1',
+          'SETD^a.2.mtx.7.mute^1',
+          'SETD^a.3.mtx.7.mute^1',
+        ]);
+      });
+
+      it('should set PRE/POST PROC on all four channels', () => {
+        const channel = conn.mtx(7).aux(3);
+
+        const messages = collectMessages(conn);
+        channel.setPostProc(true);
+        expect(messages).toEqual([
+          'SETD^a.2.mtx.6.postproc^1',
+          'SETD^a.3.mtx.6.postproc^1',
+          'SETD^a.2.mtx.7.postproc^1',
+          'SETD^a.3.mtx.7.postproc^1',
+        ]);
+      });
+
+      it('should mirror PAN only to this source on both matrices (not the neighbours)', () => {
+        const channel = conn.mtx(7).aux(3);
+
+        const messages = collectMessages(conn);
+        channel.setPan(0.5);
+        expect(messages).toEqual(['SETD^a.2.mtx.6.pan^0.5', 'SETD^a.2.mtx.7.pan^0.5']);
+      });
+    });
+
+    describe('AUX source — lower-numbered link partners (second in link)', () => {
+      it('should resolve the partner source and matrix downwards', () => {
+        conn.conn.sendMessage('SETD^a.3.stereoIndex^1'); // aux 3 & 4 linked, aux 4 second
+        conn.conn.sendMessage('SETD^a.7.stereoIndex^1'); // matrix 7 & 8 linked, matrix 8 second
+        const channel = conn.mtx(8).aux(4);
+
+        const messages = collectMessages(conn);
+        channel.setMute(true);
+        expect(messages).toEqual([
+          'SETD^a.3.mtx.7.mute^1', // self
+          'SETD^a.2.mtx.7.mute^1', // neighbour source on this matrix
+          'SETD^a.3.mtx.6.mute^1', // this source on the linked matrix
+          'SETD^a.2.mtx.6.mute^1', // neighbour source on the linked matrix
+        ]);
+      });
+    });
+
+    describe('AUX source — not linked', () => {
+      it('should only address the source itself', () => {
+        // unrelated message so the state exists and both stereo indices resolve to -1
+        conn.conn.sendMessage('SETD^m.mix^0.5');
+        const channel = conn.mtx(7).aux(3);
+
+        const messages = collectMessages(conn);
+        channel.setFaderLevel(0.5);
+        expect(messages).toEqual(['SETD^a.2.mtx.6.value^0.5']);
+      });
+    });
+
+    describe('master source', () => {
+      // The master mix has no channel index (path `m.mtx.<bus>`) and is not linkable
+      // itself, but it is mirrored across the stereo-linked matrix output.
+      it('should mirror to the master on the linked matrix output', () => {
+        conn.conn.sendMessage('SETD^a.6.stereoIndex^0'); // matrix 7 & 8 linked, matrix 7 first
+        const channel = conn.mtx(7).master();
+
+        let messages = collectMessages(conn);
+        channel.setFaderLevel(0.5);
+        expect(messages).toEqual(['SETD^m.mtx.6.value^0.5', 'SETD^m.mtx.7.value^0.5']);
+
+        // PAN uses the same single mirror as the other sends
+        messages = collectMessages(conn);
+        channel.setPan(0.5);
+        expect(messages).toEqual(['SETD^m.mtx.6.pan^0.5', 'SETD^m.mtx.7.pan^0.5']);
+      });
+
+      it('should only address the master itself when the matrix output is not linked', () => {
+        conn.conn.sendMessage('SETD^m.mix^0.5');
+        const channel = conn.mtx(7).master();
+
+        const messages = collectMessages(conn);
+        channel.setFaderLevel(0.5);
+        expect(messages).toEqual(['SETD^m.mtx.6.value^0.5']);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Improves test coverage of the `mixer-connection` library by testing **real, previously-untested behaviors** — not chasing the coverage number. Tests only; no source changes.

Coverage: statements **95.6% → 97.6%**, branches **89.4% → 95.4%**. Suite grows from 535 → 556 tests.

## What's covered

### Stereo-link command mirroring (the main gap)
`stereo-link.spec.ts` thoroughly covered master and AUX channels, but the identical (and more complex) mirroring logic for **FX** and **matrix (MTX)** channels was completely untested. A single user action can fan out to up to 4 mixer commands with special PAN semantics, so a regression there would silently break device control.

- **FX channels** — mirror to the linked neighbour source (first/second in link); no mirroring when unlinked.
- **Matrix channels** — source-only linked, matrix-output-only linked, **both linked (4 channels)**, unlinked, and the master-mix source (`m.mtx.*`). Verifies the key rule that **PAN mirrors only across the matrix-output link, never to the source neighbour**.

### Small edge cases
- `selectChannel` is a no-op when the device model is unknown.
- `playlists\$` de-duplication — both comparator branches (same-length/different-element and different-length).
- **MasterBus & matrix fade transitions** (`fadeTo`/`fadeToDB`) and `changeFaderLevelDB` from `-Infinity` dB, asserting the exact `DBToFaderValue(-97)` result.

## Deliberately out of scope
- `benchmarks-calculations/db-calculations.ts` — dev-only reference used to generate the dB LUT, not runtime API.
- Reconnect/`Reconnecting`-status lifecycle internals — low value, awkward to drive through the mock socket, partially covered already.

## Verification
- \`npx nx test mixer-connection\` — 556 passing
- \`npx nx lint mixer-connection\` — clean
- \`npx nx format:check\` — clean