### PR TITLE
chore: split changelog into per-type sections

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,39 +16,39 @@
         },
         {
           "type": "perf",
-          "section": "Other"
+          "section": "Performance Improvements"
+        },
+        {
+          "type": "test",
+          "section": "Tests"
         },
         {
           "type": "refactor",
-          "section": "Other"
+          "section": "Code Refactoring"
         },
         {
-          "type": "chore",
-          "section": "Other"
-        },
-        {
-          "type": "build",
-          "section": "Build/CI"
-        },
-        {
-          "type": "ci",
-          "section": "Build/CI"
+          "type": "deps",
+          "section": "Dependency Updates"
         },
         {
           "type": "docs",
-          "section": "Other"
+          "section": "Documentation"
+        },
+        {
+          "type": "build",
+          "section": "Build System & CI"
+        },
+        {
+          "type": "ci",
+          "section": "Build System & CI"
         },
         {
           "type": "style",
           "section": "Other"
         },
         {
-          "type": "test",
+          "type": "chore",
           "section": "Other"
-        },
-        {
-          "type": "deps",
-          "section": "Dependency updates"
         }
       ],
       "extra-files": ["packages/mixer-connection/package.json"]


### PR DESCRIPTION
## Summary

Extend the release-please config so the changelog uses distinct, meaningful sections instead of lumping most commit types into a single "Other" bucket.

Section layout:

| type | section |
|------|---------|
| `feat` | Features |
| `fix` | Bug Fixes |
| `perf` | Performance Improvements |
| `test` | Tests |
| `refactor` | Code Refactoring |
| `deps` | Dependency Updates |
| `docs` | Documentation |
| `build` · `ci` | Build System & CI |
| `style` · `chore` | Other |

Sections render in changelog order, so user-facing types (feat/fix/perf/test) come first.

## Notes

- Section assignments were chosen based on the commit types actually used in this repo's history.
- `feat` and `fix` were already sectioned; `perf` and `test` are newly promoted out of "Other".