### PR TITLE
ci: scope docs build and main build by changed paths

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'docs/**'
+      - '.github/workflows/build-docs.yml'
   pull_request:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/build-docs.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
   workflow_dispatch:
 
 # Needed for nx-set-shas when run on the main branch


### PR DESCRIPTION
## Summary

Adds path filters to the CI workflows so builds only run when relevant files change:

- **`build-docs.yml`** — now only triggers when `docs/**` (or the workflow file itself) changes.
- **`ci.yml`** — now skips runs where *only* `docs/**` files changed, via `paths-ignore`.

## Notes

- `paths-ignore` skips a run only when *every* changed file matches `docs/**`; any non-docs change still triggers CI.
- `workflow_dispatch` is unaffected by path filters, so both workflows can still be triggered manually.
- If either workflow is a *required* status check in branch protection, a skipped run won't report a status and could block merges — worth confirming branch protection settings.