### PR TITLE
ci: group docs dependabot updates to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,3 +40,16 @@ updates:
       interval: 'monthly'
     commit-message:
       prefix: 'deps'
+    groups:
+      # Docusaurus core & plugins
+      docusaurus:
+        patterns:
+          - '@docusaurus/*'
+      # React ecosystem
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'
+          - '@mdx-js/*'
+          - 'prism-react-renderer'
+          - 'clsx'


### PR DESCRIPTION
## Summary

Adds dependency groups to the `/docs` Dependabot configuration so it batches related updates into a single PR instead of opening many separate ones — mirroring the grouped approach already used for the root Nx workspace.

## Groups

- **`docusaurus`** — all `@docusaurus/*` packages (core, preset, tsconfig, types, module-type-aliases). These are versioned in lockstep (`3.5.2`), so grouping avoids a burst of separate PRs.
- **`react`** — `react`, `react-dom`, `@mdx-js/*`, `prism-react-renderer`, `clsx`.

`typescript` is intentionally left ungrouped so it still gets its own PR (unlike the root, it isn't ignored here since docs isn't managed by `nx migrate`).

Note: this branch also carries an earlier commit that restricts CI runs to the relevant paths for docs vs. main changes.