### PR TITLE
ci: always run main build so required check reports for docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,7 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - 'docs/**'
   pull_request:
-    paths-ignore:
-      - 'docs/**'
   workflow_dispatch:
 
 # Needed for nx-set-shas when run on the main branch


### PR DESCRIPTION
## Problem

Commit `941ff72` added workflow-level `paths-ignore: docs/**` to `ci.yml`. Because the `main` job is a **required status check** for PRs, docs-only PRs deadlock: GitHub skips the *entire workflow run*, so the required `main` check never reports a status and stays "Expected — waiting for status" forever, blocking the merge.

This is a known GitHub limitation — a required check skipped at the *workflow* level stays pending, whereas one skipped at the *job* level reports success.

## Fix

Remove the workflow-level `paths-ignore` so `ci.yml` always runs and the `main` check always reports a conclusive status.

Cost for docs-only PRs is negligible: `docs/` is a separate npm project outside the Nx graph, so `npx nx affected -t lint test build` finds nothing affected and the job finishes in ~a minute.

`build-docs.yml` is unaffected — it's not a required check, so its `paths` filter is fine.